### PR TITLE
Update NumPy API

### DIFF
--- a/scimath/interpolate/_interpolate.cpp
+++ b/scimath/interpolate/_interpolate.cpp
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include "interpolate.h"
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include "numpy/arrayobject.h"
 
 using namespace std;


### PR DESCRIPTION
Solves #21 
Addresses deprecation warning during build by updating to NumPy API calls from NumArray originally written.
