### PR TITLE
BUG: Fix the definition for PPG.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,12 @@
+SciMath CHANGELOG
+=================
+
+Change summary since 4.1.2
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Correct the definition of PPG to be a density unit instead of a pressure
+  gradient unit. Calculations using PPG as a pressure gradient unit can be
+  recovered simply by multiplying the PPG quantity by g, the acceleration due
+  to gravity. To precisely recover the exact values from the previous
+  definition, use ``0.0519 * psi_per_f / ppg`` for this value, which is not
+  necessarily the best estimate for g.

--- a/scimath/units/geo_units.py
+++ b/scimath/units/geo_units.py
@@ -33,7 +33,7 @@ g_ft_per_cc_s.label = 'g*ft/(cc*s)'
 
 
 ###############################################################################
-# pressure_gradient_units  psi/f, MPa/m, lb/gal, MPa/100f
+# pressure_gradient_units  psi/f, MPa/m, MPa/100f
 ###############################################################################
 
 psi_per_f  = psi/foot
@@ -43,19 +43,7 @@ psi_per_ft = psi_per_f
 MPa_per_m = MPa/meter
 MPa_per_m.label = 'MPa/m'
 
-lb_per_gal    = lb/us_fluid_gallon
-lb_per_gallon = lb_per_gal
-
-###############################################################################
-# PPG seems to have units of mass/volume and not weight/volume so we cannot
-# use the unit system to automatically convert for us unless we lie about
-# the dimensionality of ppg and pretend it is the same as psi/ft.
-###############################################################################
-# This is dimensionally inconsistant which may bite us later.
-###############################################################################
-
 psi_per_ft = pounds_per_square_inch /foot
-ppg        = psi_per_ft / 0.0519
 
 MPa_per_f  = MPa/foot
 MPa_per_f.label = 'MPa/ft'
@@ -64,6 +52,15 @@ MPa_per_100f  = MPa/(100*foot)
 MPa_per_100f.label = 'MPa/100ft'
 MPa_per_100ft = MPa_per_100f
 
+###############################################################################
+# Density units used in pressure gradient calculations
+###############################################################################
+
+lb_per_gal    = lb/us_fluid_gallon
+lb_per_gallon = lb_per_gal
+
+ppg = copy(lb_per_gal)
+ppg.label = 'ppg'
 
 ###############################################################################
 # Gamma Ray
@@ -75,4 +72,4 @@ gapi = copy(dimensionless)
 # psonic
 ###############################################################################
 us_per_ft = microsecond/foot
-us_per_ft = 'us/ft'
+us_per_ft.label = 'us/ft'

--- a/scimath/units/tests/units_test_case.py
+++ b/scimath/units/tests/units_test_case.py
@@ -28,8 +28,8 @@ import numpy
 import scimath.units as units
 from scimath.units.mass import kg, metric_ton
 from scimath.units.temperature import kelvin, celsius, fahrenheit
-from scimath.units import area, density, speed, time, frequency, \
-        acceleration, temperature, length
+from scimath.units import acceleration, area, density, frequency, geo_units, \
+    length, speed, temperature, time
 from scimath.units.quantity import Quantity
 from scimath.units.style_manager import style_manager
 from scimath.units.unit_manager import unit_manager
@@ -308,6 +308,11 @@ class test_units(unittest.TestCase):
         self.assertEqual(kgs.units('rhog').derivation, unit_parser.parse_unit('1000*kg/m**3').derivation)
         self.assertEqual(kgs.units('pvelocity').derivation, unit_parser.parse_unit('1000*m/s').derivation)
 
+    def test_ppg(self):
+        # PPG is a density measurement. It is not a pressure gradient unit. The
+        # pressure gradient can be found by multiplying the density by the
+        # acceleration due to gravity.
+        self.assertEqual(geo_units.ppg.derivation, density.gcc.derivation)
 
     #########################################################################
     # Private Methods:


### PR DESCRIPTION
The `ppg` unit is defined as a density "pounds-mass per US gallon". It is often used to measure the density of mud used in wells to balance the pressure outside of the well. It is mostly used in a hydrostatic pressure calculation `P = density*g*depth` where `g` is the acceleration due to gravity. The previous definition of `ppg` in this package folded in this constant into the unit to give the illusion that this was a pressure gradient unit. This is inconsistent with the other units used in the `mud_weight` family of units, which are also mass-density and not pressure gradients.

This PR fixes the definition of `ppg` and gives guidance on converting old code in the changelog. This is unlikely to negatively affect active projects that I am aware of.
