### PR TITLE
Fix UnitArray comparisons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ SciMath CHANGELOG
 Change summary since 4.1.2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* UnitArray comparisons will return boolean arrays, like their unadorned
+  ndarray counterpart. (#29)
 * Correct the definition of PPG to be a density unit instead of a pressure
   gradient unit. Calculations using PPG as a pressure gradient unit can be
   recovered simply by multiplying the PPG quantity by g, the acceleration due

--- a/scimath/units/tests/has_units_test_case.py
+++ b/scimath/units/tests/has_units_test_case.py
@@ -8,7 +8,7 @@ from numpy import arange, allclose, array, all #@UnresolvedImport
 from numpy.testing import assert_array_almost_equal
 
 # Enthought library imports
-from traits.testing.api import doctest_for_module, skip
+from traits.testing.api import doctest_for_module
 from scimath.units.length import feet, meters
 from scimath.units.time import second
 from scimath.units.unit_parser import unit_parser
@@ -277,67 +277,6 @@ class HasUnitsTestCase(unittest.TestCase):
         self.assertTrue(func.outputs[0].name=='out')
         self.assertTrue(func.outputs[0].units==unit_parser.parse_unit('m/s'))
 
-    def _time_conversion_decorated(self, inputs, array_size=1000,iters=1000):
-        """ Wrapped vs. normal have slowdown<1.2 (no conversion)?
-        """
-        def func(a,b,c,d):
-            return a+a,b+b,c+c,d+d
-
-        @has_units(inputs=inputs)
-        def func_wrapped(a,b,c,d):
-            return a+a,b+b,c+c,d+d
-
-        a = UnitArray(arange(array_size), units=meters/second)
-        #aa = arange(array_size)
-
-        N = iters
-        t1 = time.clock()
-        for i in range(N): #@UnusedVariable
-            w,x,y,z = func(a,a,a,a) #@UnusedVariable
-        t2 = time.clock()
-        standard = t2 - t1
-
-        t1 = time.clock()
-        for i in range(N): #@UnusedVariable
-            w,x,y,z = func_wrapped(a,a,a,a) #@UnusedVariable
-        t2 = time.clock()
-        wrapped = t2-t1
-
-        b=a
-        c=a
-        d=a
-        t1 = time.clock()
-        for i in range(N): #@UnusedVariable
-            w,x,y,z = a+a,b+b,c+c,d+d #@UnusedVariable
-        t2 = time.clock()
-        bare = t2-t1
-
-        slowdown = wrapped/standard
-        msg = ("call/s = %s, slowdown = %s; call/s = %s, slowdown = %s" %
-                  (N/wrapped, slowdown, N/bare, wrapped/bare))
-        self.assertTrue(slowdown<1.2, msg)
-
-    @skip
-    def test_time_no_conversion_decorated(self):
-        """ Wrapped vs. normal have slowdown<1.2 (no conversion)?
-        """
-        inputs="""a: description of a: units=m/s;
-                  b: description of b: units=m/s;
-                  c: description of c: units=m/s;
-                  d: description of d: units=m/s;
-               """
-        self._time_conversion_decorated(inputs=inputs)
-
-    @skip
-    def test_time_conversion_decorated(self):
-        """ Wrapped vs. normal have slowdown<1.2 (with conversion)?
-        """
-        inputs="""a: description of a: units=ft/s;
-                  b: description of b: units=ft/s;
-                  c: description of c: units=ft/s;
-                  d: description of d: units=ft/s;
-               """
-        self._time_conversion_decorated(inputs=inputs)
 
 # Some functions to play with.
 def foo(x, y):

--- a/scimath/units/tests/unit_array_test_case.py
+++ b/scimath/units/tests/unit_array_test_case.py
@@ -11,7 +11,6 @@ from numpy.testing import assert_array_equal
 
 # Enthought Library imports
 import scimath.units as units
-from traits.testing.api import skip
 from scimath.units.length import meters, feet
 from scimath.units.time import second, seconds
 from scimath.units.unit import InvalidConversion, dimensionless
@@ -184,83 +183,6 @@ class UnitArrayTestCase(unittest.TestCase):
         unit_ary.index_name = "depth"
         self.assertEqual(unit_ary.index_name, "depth")
 
-
-    ############################################################################
-    # Test Construction Speed
-    ############################################################################
-
-    @skip
-    def test_construction_is_not_slow(self):
-        """ Ensure instantiating a UnitArray is <1.1 slower than for arrays.
-
-            Note that we are using a very small array to test this case so that
-            we are seeing the "worst case" overhead.
-        """
-
-        ### Parameters #########################################################
-
-        # Slowdown we will allow compared to standard python evaluation
-        allowed_slowdown = 1.1
-
-        # Number of timer iterations.
-        N = 30000
-
-        ### Array creation #####################################################
-        setup = "from numpy import array\n"
-        expr = 'array((1,2,3))'
-        std = timeit.Timer(expr, setup)
-        std_res = std.timeit(N)
-
-        ### UnitArray creation #################################################
-        setup = "from scimath.units.api import UnitArray\n"
-        expr = 'UnitArray((1,2,3))'
-        unit_ary = timeit.Timer(expr, setup)
-        unit_ary_res = unit_ary.timeit(N)
-
-        slowdown = unit_ary_res/std_res
-        assert slowdown < allowed_slowdown, 'actual slowdown: %f' % slowdown
-
-    @skip
-    def test_finalize_is_not_slow(self):
-        """ Finalizing (cloning) a UnitArray is less than 1.1 slower than arrays
-
-            __array_finalize__ is called every time a math operation, slice,
-            etc. are called on a unit_array.  We do not want this to have much
-            overhead compared to stanard array operations.
-
-            Here, we compare the speed of adding 1 to an array and to a
-            UnitArray.
-
-            Note that we are using a very small array to test this case so that
-            we are seeing the "worst case" overhead.
-        """
-
-        ### Parameters #########################################################
-
-        # Slowdown we will allow compared to standard python evaluation
-        allowed_slowdown = 1.1
-
-        # Number of timer iterations.
-        N = 30000
-
-        ### Array ##############################################################
-        setup = "from numpy import array\n" \
-                "val = array((1,2,3))\n"
-        expr = 'val+1'
-        std = timeit.Timer(expr, setup)
-        std_res = std.timeit(N)
-
-        ### UnitArray ##########################################################
-        setup = (
-            "from scimath.units.api import UnitArray\n"
-            "val = UnitArray((1,2,3))\n"
-        )
-        expr = 'val+1'
-        unit_ary = timeit.Timer(expr, setup)
-        unit_ary_res = unit_ary.timeit(N)
-
-        slowdown = unit_ary_res/std_res
-        assert slowdown < allowed_slowdown, 'actual slowdown: %f' % slowdown
 
 class UnitArrayPickleTestCase(unittest.TestCase):
 

--- a/scimath/units/tests/unit_array_test_case.py
+++ b/scimath/units/tests/unit_array_test_case.py
@@ -4,11 +4,10 @@ import timeit
 import unittest
 import operator
 
-from nose import SkipTest
-
 # Numeric library imports
 import numpy
 from numpy import all, array, sqrt
+from numpy.testing import assert_array_equal
 
 # Enthought Library imports
 import scimath.units as units
@@ -327,17 +326,17 @@ class PassUnitsTestCase(unittest.TestCase):
         b = 1
         result = a - b
         self.assertEqual(result.units, dimensionless)
-        self.assertEqual(result, UnitArray([0,1,2], units=dimensionless))
+        assert_array_equal(result, UnitArray([0,1,2], units=dimensionless))
         result = b - a
         self.assertEqual(result.units, dimensionless)
-        self.assertEqual(result, UnitArray([0,-1,-2], units=dimensionless))
+        assert_array_equal(result, UnitArray([0,-1,-2], units=dimensionless))
         c = array([3,2,1])
         result = a - c
         self.assertEqual(result.units, dimensionless)
-        self.assertEqual(result, UnitArray([-2,0,2], units=dimensionless))
+        assert_array_equal(result, UnitArray([-2,0,2], units=dimensionless))
         result = c - a
         self.assertEqual(result.units, dimensionless)
-        self.assertEqual(result, UnitArray([2,0,-2], units=dimensionless))
+        assert_array_equal(result, UnitArray([2,0,-2], units=dimensionless))
 
     def test_divide_pass(self):
         a = UnitArray([1,2,3],units=meters/second)
@@ -399,9 +398,6 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,1.0,1], units=2.0*dimensionless)
         result = a <= b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], True)
         self.assertEqual(result[2], False)
@@ -419,18 +415,15 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,2.0,1], units=2.0*dimensionless)
         result = a < b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)
         self.assertEqual(result[2], False)
-        c = 4.0
+        c = 3.0
         result = b < c
         self.assertEqual(result[0], False)
-        self.assertEqual(result[1], False)
+        self.assertEqual(result[1], True)
         self.assertEqual(result[2], True)
-        d = array([1.0, 4.0, 3.0])
+        d = array([1.0, 2.0, 3.0])
         result = b < d
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], False)
@@ -441,18 +434,15 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,2.0,1], units=2.0*dimensionless)
         result = a >= b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], True)
         self.assertEqual(result[2], True)
-        c = 4.0
+        c = 2.0
         result = b >= c
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], True)
         self.assertEqual(result[2], False)
-        d = array([1.0, 4.0, 3.0])
+        d = array([1.0, 2.0, 3.0])
         result = b >= d
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], True)
@@ -463,13 +453,10 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,2.0,1], units=2.0*dimensionless)
         result = a > b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], False)
         self.assertEqual(result[2], True)
-        c = 4.0
+        c = 2.0
         result = b > c
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)
@@ -485,18 +472,15 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,2.0,1], units=2.0*dimensionless)
         result = a == b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], True)
         self.assertEqual(result[2], False)
-        c = 4.0
+        c = 2.0
         result = b == c
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], True)
         self.assertEqual(result[2], False)
-        d = array([1.0, 4.0, 3.0])
+        d = array([1.0, 2.0, 3.0])
         result = b == d
         self.assertEqual(result[0], False)
         self.assertEqual(result[1], True)
@@ -507,19 +491,16 @@ class PassUnitsTestCase(unittest.TestCase):
         b = UnitArray([3.0,2.0,1], units=2.0*dimensionless)
         result = a != b
 
-        # FIXME: these tests fail
-        raise SkipTest
-
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)
         self.assertEqual(result[2], True)
-        c = 4.0
+        c = 2.0
         result = b != c
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)
         self.assertEqual(result[2], True)
 
-        d = array([1.0, 4.0, 3.0])
+        d = array([1.0, 2.0, 3.0])
         result = b != d
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)

--- a/scimath/units/unit_array.py
+++ b/scimath/units/unit_array.py
@@ -395,8 +395,6 @@ class UnitArray(numpy.ndarray):
         """
         other, u = self.__convert_other(other)
         result = super(UnitArray, self).__le__(other)
-        if isinstance(result, numpy.ndarray):
-            return result.all()
         return result
 
     def __lt__(self, other):
@@ -405,8 +403,6 @@ class UnitArray(numpy.ndarray):
         """
         other, u = self.__convert_other(other)
         result = super(UnitArray, self).__lt__(other)
-        if isinstance(result, numpy.ndarray):
-            return result.all()
         return result
 
     def __ge__(self, other):
@@ -415,8 +411,6 @@ class UnitArray(numpy.ndarray):
         """
         other, u = self.__convert_other(other)
         result = super(UnitArray, self).__ge__(other)
-        if isinstance(result, numpy.ndarray):
-            return result.all()
         return result
 
     def __gt__(self, other):
@@ -425,8 +419,6 @@ class UnitArray(numpy.ndarray):
         """
         other, u = self.__convert_other(other)
         result = super(UnitArray, self).__gt__(other)
-        if isinstance(result, numpy.ndarray):
-            return result.all()
         return result
 
     def __eq__(self, other):
@@ -436,8 +428,6 @@ class UnitArray(numpy.ndarray):
         try:
             other, u = self.__convert_other(other)
             result = super(UnitArray, self).__eq__(other)
-            if isinstance(result, numpy.ndarray):
-                return result.all()
             return result
         except:
             return False
@@ -449,8 +439,6 @@ class UnitArray(numpy.ndarray):
         try:
             other, u = self.__convert_other(other)
             result = super(UnitArray, self).__ne__(other)
-            if isinstance(result, numpy.ndarray):
-                return result.all()
             return result
         except:
             return True

--- a/scimath/units/unit_array.py
+++ b/scimath/units/unit_array.py
@@ -2,8 +2,8 @@
 import numpy
 
 # Enthought library imports
-import scimath.units as units
-from scimath.units.unit import dimensionless
+from scimath.units import convert
+from scimath.units.unit import unit, dimensionless, IncompatibleUnits
 from scimath.units.unit_parser import unit_parser
 
 def __newobj__ ( cls, *args ):
@@ -55,7 +55,7 @@ class UnitArray(numpy.ndarray):
     ############################################################################
 
     # Units specification.  it is a scimath.units.unit object, not a string.
-    # units = Instance(units.unit)
+    # units = Instance(unit)
 
     # 'type' specifies the type of UnitArray.
     # This could be useful for specifying that this is a 'tops' UnitArray or of
@@ -229,18 +229,18 @@ class UnitArray(numpy.ndarray):
         if su == None and ou == None:
             u = None
         else:
-            if isinstance(other, units.unit.unit):
+            if isinstance(other, unit):
                 # Handles 5 * liters
-                ou = units.unit.unit(1, other.derivation)
-                other = units.convert(other.value, ou, su)
+                ou = unit(1, other.derivation)
+                other = convert(other.value, ou, su)
             elif isinstance(other, UnitArray):
                 # Handles UnitArray or UnitScalar
-                other = units.convert(numpy.array(other), ou, su)
+                other = convert(numpy.array(other), ou, su)
             elif isinstance(other, numpy.ndarray):
                 if len(other.shape) > 0 and hasattr(other.item(0), 'derivation'):
                     # Handles array([1,2,3] * liters)
-                    ou = units.unit.unit(1, other.item(0).derivation)
-                    other = units.convert(other/ou, ou, su)
+                    ou = unit(1, other.item(0).derivation)
+                    other = convert(other/ou, ou, su)
             u = su
         return other, u
 
@@ -373,7 +373,7 @@ class UnitArray(numpy.ndarray):
                 if getattr(other, "units", dimensionless) == dimensionless:
                     other = float(other)
                 else:
-                    raise units.IncompatibleUnits, "exponent must be dimensionless"
+                    raise IncompatibleUnits("exponent must be dimensionless")
             result = super(UnitArray, self).__pow__(other)
             su = getattr(self, 'units', None)
             if su:
@@ -451,8 +451,8 @@ class UnitArray(numpy.ndarray):
         """ Convert UnitArray from its current units to a new set of units.
 
         """
-        result = self.__class__(units.convert(self.view(numpy.ndarray),
-                                              self.units, new_units))
+        result = self.__class__(convert(self.view(numpy.ndarray),
+                                        self.units, new_units))
         result.units = new_units
 
         return result

--- a/scimath/units/unit_array.py
+++ b/scimath/units/unit_array.py
@@ -241,9 +241,6 @@ class UnitArray(numpy.ndarray):
                     # Handles array([1,2,3] * liters)
                     ou = units.unit.unit(1, other.item(0).derivation)
                     other = units.convert(other/ou, ou, su)
-            else:
-                #Everything else
-                other = units.convert(numpy.array(other), ou, su)
             u = su
         return other, u
 


### PR DESCRIPTION
Moved from #4. `UnitArray` comparisons will now return boolean arrays, just like `ndarray`s normally do, and how `UnitArray`s used to behave. I believe that the code that relied on scalar bools coming out has been fixed.