### PR TITLE
Dimensionless `fract` unit seen in the wild in well logs.

### DIFF
--- a/scimath/units/dimensionless.py
+++ b/scimath/units/dimensionless.py
@@ -9,7 +9,7 @@ from scimath.units.unit import one, dim
 fractional = copy(dimensionless)
 fractional.label = 'V/V'
 fraction = fractional
-ratio = frac = fractional
+ratio = frac = fract = fractional
 
 percent = fractional / 100.
 percent.label = '%'

--- a/scimath/units/unit_parser.py
+++ b/scimath/units/unit_parser.py
@@ -99,6 +99,7 @@ class Parser(Singleton):
         import angle
         import area
         import density
+        import dimensionless
         import electromagnetism
         import energy
         import force
@@ -114,9 +115,11 @@ class Parser(Singleton):
         import volume
         import geo_units
 
-        modules = [ SI, acceleration, angle, area, density, electromagnetism,
-            energy, force, frequency, length, mass, power, pressure,
-            speed, substance, temperature, time, volume, geo_units ]
+        modules = [
+            SI, acceleration, angle, area, density, dimensionless,
+            electromagnetism, energy, force, frequency, length, mass, power,
+            pressure, speed, substance, temperature, time, volume, geo_units
+        ]
 
         return modules
 


### PR DESCRIPTION
Added the `dimensionless` module to the unit parser: they where not parsed in well-log-related code.
