### PR TITLE
Fix/bug parser extend

### DIFF
--- a/scimath/units/unit_parser.py
+++ b/scimath/units/unit_parser.py
@@ -61,15 +61,13 @@ class Parser(Singleton):
         return value
 
     def init(self, *args, **kwds):
-        self.context = self._initializeContext()
-        self._cacheExactLabels()
+        self._initializeContext()
 
     def _initializeContext(self):
-        context = {}
+        self.context = context = {}
         modules = self._loadModules()
-        for module in  modules:
-            context.update(module.__dict__)
-        self._cleanContext(context)
+        self.extend(*modules)
+
         # Add the SI names used in the derivations and labels but not
         # already in the context.
         context['A'] = context['amp']

--- a/scimath/units/unit_parser.py
+++ b/scimath/units/unit_parser.py
@@ -41,7 +41,7 @@ class Parser(Singleton):
     def extend(self, *modules):
         for module in modules:
             self.context.update(module.__dict__)
-        self._cleanContext(context)
+        self._cleanContext(self.context)
         self._cacheExactLabels()
 
     def parse(self, string):


### PR DESCRIPTION
This PR makes the following changes:
* fixes a bug that causes the unit parser to throw a `NameError` when custom units are added to the parser. 
* Slight refactor of initialization method to re-use the `extend` method.

closes https://github.com/enthought/scimath/issues/41