### PR TITLE
Adding unit test for extending unit parser

### DIFF
--- a/scimath/units/tests/sample_units.py
+++ b/scimath/units/tests/sample_units.py
@@ -4,6 +4,4 @@ from copy import copy
 
 
 custom_unit = copy(mm)
-
-custom_unit_with_label = copy(mm)
-custom_unit_with_label.label = "cuwl"
+custom_unit.label = "cuwl"

--- a/scimath/units/tests/sample_units.py
+++ b/scimath/units/tests/sample_units.py
@@ -1,8 +1,9 @@
 
 from scimath.units.length import mm
+from copy import copy
 
 
-custom_unit = mm
+custom_unit = copy(mm)
 
-custom_unit_with_label = mm
+custom_unit_with_label = copy(mm)
 custom_unit_with_label.label = "cuwl"

--- a/scimath/units/tests/sample_units.py
+++ b/scimath/units/tests/sample_units.py
@@ -1,0 +1,8 @@
+
+from scimath.units.length import mm
+
+
+custom_unit = mm
+
+custom_unit_with_label = mm
+custom_unit_with_label.label = "cuwl"

--- a/scimath/units/tests/test_custom_unit_parser.py
+++ b/scimath/units/tests/test_custom_unit_parser.py
@@ -3,16 +3,20 @@
 import unittest
 
 from scimath.units.api import unit_parser
-from scimath.units.length import mm
 from scimath.units.unit_parser import UnableToParseUnits
 from scimath.units.tests import sample_units
+
 
 class TestCustomUnitParser(unittest.TestCase):
 
     def test_extend_from_module(self):
-        # Custom units are not known initially
+        # Custom unit is not known initially
         with self.assertRaises(UnableToParseUnits):
             unit_parser.parse_unit("custom_unit", suppress_unknown=False)
 
         unit_parser.parser.extend(sample_units)
-        self.assertEqual(unit_parser.parse_unit("cuwl"), mm)
+
+        # Once parser is extended, the unit can be parsed
+        expected_unit = sample_units.custom_unit
+        self.assertEqual(unit_parser.parse_unit("custom_unit"), expected_unit)
+        self.assertEqual(unit_parser.parse_unit("cuwl"), expected_unit)

--- a/scimath/units/tests/test_custom_unit_parser.py
+++ b/scimath/units/tests/test_custom_unit_parser.py
@@ -5,9 +5,7 @@ import unittest
 from scimath.units.api import unit_parser
 from scimath.units.length import mm
 from scimath.units.unit_parser import UnableToParseUnits
-import sample_units
-
-
+from scimath.units.tests import sample_units
 
 class TestCustomUnitParser(unittest.TestCase):
 

--- a/scimath/units/tests/test_custom_unit_parser.py
+++ b/scimath/units/tests/test_custom_unit_parser.py
@@ -12,10 +12,7 @@ class TestCustomUnitParser(unittest.TestCase):
     def test_extend_from_module(self):
         # Custom units are not known initially
         with self.assertRaises(UnableToParseUnits):
-            unit_parser.parse_unit("cuwl", suppress_unknown=False)
-        with self.assertRaises(UnableToParseUnits):
             unit_parser.parse_unit("custom_unit", suppress_unknown=False)
 
         unit_parser.parser.extend(sample_units)
         self.assertEqual(unit_parser.parse_unit("cuwl"), mm)
-        self.assertEqual(unit_parser.parse_unit("custom_unit"), mm)

--- a/scimath/units/tests/test_custom_unit_parser.py
+++ b/scimath/units/tests/test_custom_unit_parser.py
@@ -1,0 +1,23 @@
+""" Tests for customizing the unit parser.
+"""
+import unittest
+
+from scimath.units.api import unit_parser
+from scimath.units.length import mm
+from scimath.units.unit_parser import UnableToParseUnits
+import sample_units
+
+
+
+class TestCustomUnitParser(unittest.TestCase):
+
+    def test_extend_from_module(self):
+        # Custom units are not known initially
+        with self.assertRaises(UnableToParseUnits):
+            unit_parser.parse_unit("cuwl", suppress_unknown=False)
+        with self.assertRaises(UnableToParseUnits):
+            unit_parser.parse_unit("custom_unit", suppress_unknown=False)
+
+        unit_parser.parser.extend(sample_units)
+        self.assertEqual(unit_parser.parse_unit("cuwl"), mm)
+        self.assertEqual(unit_parser.parse_unit("custom_unit"), mm)


### PR DESCRIPTION
@senganal Added a test for your fix in #42 . This extend feature used to work and cannot be broken silently.