### PR TITLE
BUG: Fix tests for compatibility with newer numpy versions.

### DIFF
--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -15,7 +15,7 @@ class Test(unittest.TestCase):
         self.assert_(allclose(x, y))
 
     def test_linear(self):
-        N = 3000.
+        N = 3000
         x = arange(N)
         y = arange(N)
         new_x = arange(N) + 0.5
@@ -26,7 +26,7 @@ class Test(unittest.TestCase):
         self.assertAllclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
 
     def test_block_average_above(self):
-        N = 3000.
+        N = 3000
         x = arange(N)
         y = arange(N)
 
@@ -38,7 +38,7 @@ class Test(unittest.TestCase):
         self.assertAllclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
 
     def test_linear2(self):
-        N = 3000.
+        N = 3000
         x = arange(N)
         y = ones((100, N)) * arange(N)
         new_x = arange(N) + 0.5
@@ -54,7 +54,7 @@ class Test(unittest.TestCase):
                              [0.5, 1.5, 2.5, 3.5, 4.5]])
 
     def test_interp1d(self):
-        N = 3000.
+        N = 3000
         x = arange(N)
         y = ones((100, N)) * arange(N)
         new_x = arange(N)

--- a/scimath/units/has_units.py
+++ b/scimath/units/has_units.py
@@ -139,13 +139,13 @@ def has_units(func=None, summary='', doc='', inputs=None, outputs=None):
 
             >>> from numpy import array
             >>> a = array((1,2,3))
-            >>> add(a,a)
-            array([ 0.6096,  1.2192,  1.8288])
+            >>> add(a,a) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+            array([...0.6096, 1.2192, 1.8288])
 
             >>> from scimath.units.length import m
             >>> a = UnitArray((1,2,3), units=m)
-            >>> add(a,a) # (Converts m -> ft -> m)
-            UnitArray([ 2.,  4.,  6.], units='1.0*m')
+            >>> add(a,a) # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+            UnitArray([...2., 4., 6.], units='1.0*m')
             >>> add(a,a).units
             1.0*m
 


### PR DESCRIPTION
Recent numpy versions don't like floating point numbers in shape tuples, and also omit some whitespace in array `repr`s.