### PR TITLE
BUG: Clean up NameErrors.

### DIFF
--- a/scimath/physical_quantities/units.py
+++ b/scimath/physical_quantities/units.py
@@ -12,6 +12,7 @@ from traits.api import HasTraits, Float, String, Unicode, Bool, \
 #from traitsui.api import View, Item, Group
 
 from .dimensions import Dimensions, Dim
+from .util import dict_add, dict_sub, dict_mul, format_expansion, unicode_powers
 
 
 class Unit(HasTraits):
@@ -249,7 +250,7 @@ class DerivedUnit(MultiplicativeUnit):
     def get_symbol(self):
         return format_expansion(dict((key.symbol, power)
                                      for key, power in self.derivation.items()),
-                                mul=" ", pow_func=unicode_power, div=True)
+                                mul=" ", pow_func=unicode_powers, div=True)
 
     @cached_property
     def get_expression(self):
@@ -258,7 +259,7 @@ class DerivedUnit(MultiplicativeUnit):
 
     @cached_property
     def get_dimensions(self):
-        dim = dimensionless
+        dim = Dimensions({})
         for key, power in self.derivation.items():
             dim *= key.dimensions**power
         return dim

--- a/scimath/units/quantity.py
+++ b/scimath/units/quantity.py
@@ -135,7 +135,7 @@ class Quantity(HasPrivateTraits):
                     family_name = self.family_name.lower()
                 self.family_name = \
                     um.get_family_name(family_name) or \
-                    em.get_family_name(name.lower())
+                    um.get_family_name(name.lower())
 
                 # If units were passed in, but don't match the guessed family_name,
                 # punt.

--- a/scimath/units/unit_db.py
+++ b/scimath/units/unit_db.py
@@ -108,6 +108,7 @@ class UnitDB(object):
         #  manager).
 
         is_data = False
+        column_names = []
 
         if not filename:
             filename = os.path.join(get_path(self), 'data',
@@ -160,6 +161,7 @@ class UnitDB(object):
                                     'unit_families.txt')
 
         is_data = False
+        converters = []
         fh = open(filename)
 
         logger.debug('Loading default unit info from %s...' % filename)
@@ -201,6 +203,8 @@ class UnitDB(object):
         #  manager).
 
         is_data = False
+        column_names = []
+        system_names = []
 
         if not filename:
             filename = os.path.join(get_path(self), 'data',

--- a/scimath/units/unit_manager.py
+++ b/scimath/units/unit_manager.py
@@ -228,7 +228,7 @@ class UnitManager(HasPrivateTraits):
     def add_system(self, system):
         """ Adds unit system(s) to the unit_manager's list of systems
         """
-        self.unit_systems.append(us)
+        self.unit_systems.append(system)
 
     def add_member(self, member_name, family):
         """ Adds a member to the unit_members dict used to lookup unit aliases


### PR DESCRIPTION
Some of these are obvious typos and refactoring leftovers. There are still
a few in `scimath.physical_quantities` because that package looks like
unfinished work.

Fixes #51 (or what I can of it).