### PR TITLE
Use git revision based dev version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # file types to ignore
+*/_version.py
 *.pyc
 *.pyd
 *.so

--- a/scimath/__init__.py
+++ b/scimath/__init__.py
@@ -1,8 +1,4 @@
 # Copyright (c) 2007-2015 by Enthought, Inc.
 # All rights reserved.
 
-__version__ = '4.1.3.dev0'
-
-__requires__ = [
-    'traits',
-]
+from scimath._version import full_version as __version__, git_revision as __git_revision__  # noqa

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ def configuration(parent_package='', top_path=None):
 
 DEPENDENCIES = [
     'traits',
+    'scipy',
 ]
 
 
@@ -153,7 +154,6 @@ if __name__ == "__main__":
         description = 'scientific and mathematical calculations',
         long_description = open('README.rst').read(),
         install_requires = DEPENDENCIES,
-        setup_requires=['numpy'],
         license = "BSD",
         package_data = {'': ['images/*', 'data/*']},
         platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,92 @@
 # Copyright (c) 2008-2013 by Enthought, Inc.
 # All rights reserved.
-from __future__ import absolute_import
-from os.path import join
-
-# NOTE: Setuptools must be imported BEFORE numpy.distutils or else
-# numpy.distutils won't do the correct thing.
-import setuptools
+import os
+import re
+from setuptools import find_packages, setup
+from subprocess import check_output
 
 import numpy.distutils.core
 
 
-info = {}
-exec(compile(open(join('scimath', '__init__.py')).read(), join('scimath', '__init__.py'), 'exec'), info)
+MAJOR = 4
+MINOR = 1
+MICRO = 3
+IS_RELEASED = False
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+VERSION_FILE_TEMPLATE = """\
+# This file is generated from setup.py
+version = '{version}'
+full_version = '{full_version}'
+git_revision = '{git_revision}'
+is_released = {is_released}
+if not is_released:
+    version = full_version
+"""
+DEFAULT_VERSION_FILE = os.path.join('scimath', '_version.py')
+
+
+# Return the git revision as a string
+def git_version():
+    def _minimal_ext_cmd(cmd):
+        # construct minimal environment
+        env = {}
+
+        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        out = check_output(cmd, env=env)
+        return out
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-parse', 'HEAD'])
+        git_revision = out.strip().decode('ascii')
+    except OSError:
+        git_revision = "Unknown"
+    try:
+        out = _minimal_ext_cmd(['git', 'rev-list', '--count', 'HEAD'])
+        git_count = out.strip().decode('ascii')
+    except OSError:
+        git_count = '0'
+    return git_revision, git_count
+
+
+def write_version_py(filename=DEFAULT_VERSION_FILE,
+                     template=VERSION_FILE_TEMPLATE):
+    # Adding the git rev number needs to be done inside
+    # write_version_py(), otherwise the import of scimath._version messes
+    # up the build under Python 3.
+    fullversion = VERSION
+    if os.path.exists('.git'):
+        git_rev, dev_num = git_version()
+    elif os.path.exists(DEFAULT_VERSION_FILE):
+        # must be a source distribution, use existing version file
+        try:
+            from scimath._version import git_revision as git_rev
+            from scimath._version import full_version as full_v
+        except ImportError:
+            raise ImportError("Unable to import git_revision. Try removing "
+                              "scimath/_version.py and the build directory "
+                              "before building.")
+        match = re.match(r'.*?\.dev(?P<dev_num>\d+)$', full_v)
+        if match is None:
+            dev_num = '0'
+        else:
+            dev_num = match.group('dev_num')
+    else:
+        git_rev = "Unknown"
+        dev_num = '0'
+    if not IS_RELEASED:
+        fullversion += '.dev{0}'.format(dev_num)
+    with open(filename, "wt") as fp:
+        fp.write(template.format(version=VERSION,
+                                 full_version=fullversion,
+                                 git_revision=git_rev,
+                                 is_released=IS_RELEASED))
+    return fullversion
 
 
 # Setup our extensions to Python.
@@ -33,47 +108,55 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
-# Build the full set of packages by appending any found by setuptools'
-# find_packages to those discovered by numpy.distutils.
-config = configuration().todict()
-packages = setuptools.find_packages(exclude=config['packages'] +
-                                    ['docs', 'examples'])
-config['packages'] += packages
+DEPENDENCIES = [
+    'traits',
+]
 
 
-# The actual setup call.
-numpy.distutils.core.setup(
-    name = 'scimath',
-    version = info['__version__'],
-    author = 'Enthought, Inc',
-    author_email = 'info@enthought.com',
-    maintainer = 'ETS Developers',
-    maintainer_email = 'enthought-dev@enthought.com',
-    url = 'https://github.com/enthought/scimath',
-    download_url = ('https://github.com/enthought/scimath/archive/%s.tar.gz' %
-                    info['__version__']),
-    classifiers = [c.strip() for c in """\
-        Development Status :: 4 - Beta
-        Intended Audience :: Developers
-        Intended Audience :: Science/Research
-        License :: OSI Approved :: BSD License
-        Operating System :: MacOS
-        Operating System :: Microsoft :: Windows
-        Operating System :: OS Independent
-        Operating System :: POSIX
-        Operating System :: Unix
-        Programming Language :: C
-        Programming Language :: Python
-        Topic :: Scientific/Engineering
-        Topic :: Software Development
-        Topic :: Software Development :: Libraries
-        """.splitlines() if len(c.split()) > 0],
-    description = 'scientific and mathematical calculations',
-    long_description = open('README.rst').read(),
-    install_requires = info['__requires__'],
-    license = "BSD",
-    package_data = {'': ['images/*', 'data/*']},
-    platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
-    zip_safe = False,
-    **config
-)
+if __name__ == "__main__":
+    __version__ = write_version_py()
+
+    # Build the full set of packages by appending any found by setuptools'
+    # find_packages to those discovered by numpy.distutils.
+    config = configuration().todict()
+    packages = find_packages(exclude=config['packages'] +
+                                        ['docs', 'examples'])
+    config['packages'] += packages
+
+    # The actual setup call.
+    numpy.distutils.core.setup(
+        name = 'scimath',
+        version = __version__,
+        author = 'Enthought, Inc',
+        author_email = 'info@enthought.com',
+        maintainer = 'ETS Developers',
+        maintainer_email = 'enthought-dev@enthought.com',
+        url = 'https://github.com/enthought/scimath',
+        download_url = ('https://github.com/enthought/scimath/archive/%s.tar.gz' %
+                        __version__),
+        classifiers = [c.strip() for c in """\
+            Development Status :: 4 - Beta
+            Intended Audience :: Developers
+            Intended Audience :: Science/Research
+            License :: OSI Approved :: BSD License
+            Operating System :: MacOS
+            Operating System :: Microsoft :: Windows
+            Operating System :: OS Independent
+            Operating System :: POSIX
+            Operating System :: Unix
+            Programming Language :: C
+            Programming Language :: Python
+            Topic :: Scientific/Engineering
+            Topic :: Software Development
+            Topic :: Software Development :: Libraries
+            """.splitlines() if len(c.split()) > 0],
+        description = 'scientific and mathematical calculations',
+        long_description = open('README.rst').read(),
+        install_requires = DEPENDENCIES,
+        setup_requires=['numpy'],
+        license = "BSD",
+        package_data = {'': ['images/*', 'data/*']},
+        platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
+        zip_safe = False,
+        **config
+    )


### PR DESCRIPTION
Previously, the dev version was hardcoded in the `__init__` file.

Dev revision numbers are set based on the number of commits since the beginning. For example, if the code is installed from this branch, the version number will be `4.1.3.dev325`

Note that this PR explicitly adds `scipy` as a runtime dependency of the package.
~Note that this PR also explicitly passes `numpy` to the `build_requires` kwarg in `setup`.~