### PR TITLE
Add a pyproject.toml file declaring NumPy as a build dependency.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,6 @@ include image_LICENSE_OOo.txt
 include image_LICENSE.txt
 include LICENSE.txt
 include README.rst
+include pyproject.toml
 recursive-include scimath/units/data/*
 recursive-include scimath/units/plugin/images/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["numpy", "setuptools", "wheel"]


### PR DESCRIPTION
This PR adds a minimal `pyproject.toml` file to declare NumPy as a build dependency. Without this, a `pip install scimath` in an environment that doesn't have NumPy installed will fail.

See [PEP 518](https://www.python.org/dev/peps/pep-0518/) for more information on use of `pyproject.toml`.

This fixes #76.