### PR TITLE
Fix unit hash

### DIFF
--- a/scimath/units/tests/test_unit.py
+++ b/scimath/units/tests/test_unit.py
@@ -1,6 +1,7 @@
 import unittest
 
 from scimath.units.length import centimeter, meter
+from scimath.units.unit import unit
 
 
 class TestUnit(unittest.TestCase):
@@ -11,3 +12,9 @@ class TestUnit(unittest.TestCase):
         }
         self.assertEqual(unit_label_mapping[meter], 'a meter')
         self.assertEqual(unit_label_mapping[centimeter], 'a centimeter')
+
+    def test_units_should_hash_equal_if_they_compare_equal(self):
+        meter = unit(1.0, (1, 0, 0, 0, 0, 0, 0))
+        metre = unit(1.0, (1, 0, 0, 0, 0, 0, 0))
+        self.assertEqual(meter, metre)
+        self.assertEqual(hash(meter), hash(metre))

--- a/scimath/units/tests/test_unit.py
+++ b/scimath/units/tests/test_unit.py
@@ -7,7 +7,7 @@ class TestUnit(unittest.TestCase):
     def test_hashability_of_unit(self):
         unit_label_mapping = {
             meter: 'a meter',
-            centimeter: 'a centimerer'
+            centimeter: 'a centimeter'
         }
-        self.assertTrue(unit_label_mapping[meter], 'a meter')
-        self.assertTrue(unit_label_mapping[centimeter], 'a centimeter')
+        self.assertEqual(unit_label_mapping[meter], 'a meter')
+        self.assertEqual(unit_label_mapping[centimeter], 'a centimeter')

--- a/scimath/units/tests/test_unit.py
+++ b/scimath/units/tests/test_unit.py
@@ -1,0 +1,13 @@
+import unittest
+
+from scimath.units.length import centimeter, meter
+
+
+class TestUnit(unittest.TestCase):
+    def test_hashability_of_unit(self):
+        unit_label_mapping = {
+            meter: 'a meter',
+            centimeter: 'a centimerer'
+        }
+        self.assertTrue(unit_label_mapping[meter], 'a meter')
+        self.assertTrue(unit_label_mapping[centimeter], 'a centimeter')

--- a/scimath/units/unit.py
+++ b/scimath/units/unit.py
@@ -61,12 +61,8 @@ class unit(object):
             self.derivation != other.derivation or\
             self.offset != other.offset
 
-    # FIXME : This is a temporary workaround necessary to be able to hash
-    # `unit` instances on Python 3.
-    # A proper solution would be to generate the hash based on the contents
-    # of the `unit` object. See discussion on GitHub issue
-    # https://github.com/enthought/scimath/issues/87
-    __hash__ =  object.__hash__
+    def __hash__(self):
+        return hash(("scimath.unit", self.value, self.derivation, self.offset))
 
     def __add__(self, other):
         if not self.derivation == other.derivation:

--- a/scimath/units/unit.py
+++ b/scimath/units/unit.py
@@ -61,6 +61,13 @@ class unit(object):
             self.derivation != other.derivation or\
             self.offset != other.offset
 
+    # FIXME : This is a temporary workaround necessary to be able to hash
+    # `unit` instances on Python 3.
+    # A proper solution would be to generate the hash based on the contents
+    # of the `unit` object. See discussion on GitHub issue
+    # https://github.com/enthought/scimath/issues/87
+    __hash__ =  object.__hash__
+
     def __add__(self, other):
         if not self.derivation == other.derivation:
             raise IncompatibleUnits("add", self, other)


### PR DESCRIPTION
Fixes #87 

The `unit` object does not explicitly define `__hash__`. On Python 2, this is acceptable as `__hash__` will be inherited from `object`. OTOH, on Python 3, `__hash__` will be set to `None`, making `unit` instances unhashable. Note that this behavior is because `unit` defines `__eq__`.

A bug in the existing implementation of `unit` leads to a fundamental issue - in Python, if two objects compare equal, their hash values should be equal. This is not the case on Python 2 at the moment as the default `__hash__` method inherited from `object` will simply return the object's `id`.

This PR fixes the issue by explicitly defining the  `__hash__` method as `hash(("scimath.unit", self.value, self.derivation, self.offset))`, based on Mark's suggestion (see https://github.com/enthought/scimath/pull/88#issuecomment-490782264 )