### PR TITLE
Use the correct format when recursively including files via Manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include image_LICENSE.txt
 include LICENSE.txt
 include README.rst
 include pyproject.toml
-recursive-include scimath/units/data/*
-recursive-include scimath/units/plugin/images/*
+recursive-include scimath/units/data/ *.txt
+recursive-include scimath/units/plugin/images *.txt *.png

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,5 @@ include image_LICENSE.txt
 include LICENSE.txt
 include README.rst
 include pyproject.toml
-recursive-include scimath/units/data/ *.txt
+recursive-include scimath/units/data *.txt
 recursive-include scimath/units/plugin/images *.txt *.png


### PR DESCRIPTION
I noticed errors of the type - 
```
...
reading manifest template 'MANIFEST.in'
warning: manifest_maker: MANIFEST.in, line 7: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

warning: manifest_maker: MANIFEST.in, line 8: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

writing manifest file 'scimath.egg-info/SOURCES.txt'
...
```
in the CI job https://travis-ci.com/enthought/scimath/jobs/258169832 .

This is because, as the error message suggests, we are using the wrong format when using `recursive-include`.

This PR fixes that issue.