### PR TITLE
Remove usage of deprecated methods

### DIFF
--- a/scimath/units/quantity_trait.py
+++ b/scimath/units/quantity_trait.py
@@ -57,7 +57,7 @@ class QuantityTraitHandler (TraitHandler):
                 return value
         except:
             pass
-        self.error(object, name, self.repr(value))
+        self.error(object, name, value)
 
     def post_setattr(self, object, name, value):
         q = self.quantity

--- a/scimath/units/quantity_traits.py
+++ b/scimath/units/quantity_traits.py
@@ -80,7 +80,7 @@ class QuantityHandler (TraitHandler):
                                 family_name=self.family_name)
         except:
             pass
-        self.error(object, name, self.repr(value))
+        self.error(object, name, value)
 
     def info(self):
         article = 'a'


### PR DESCRIPTION
The `BaseTraitHandler.repr` method was originally deprecated in traits version 3.0.3 and the PR https://github.com/enthought/traits/pull/599 is removing the method entirely.

- [ ] add tests exercising the objects and the branches.