### PR TITLE
Replace uses of convenience trait types

### DIFF
--- a/scimath/physical_quantities/dimensions.py
+++ b/scimath/physical_quantities/dimensions.py
@@ -22,7 +22,7 @@ from __future__ import division
 # Enthought module imports
 from __future__ import absolute_import
 from traits.api import (
-    HasTraits, String, DictStrFloat, Property, TraitType, TraitError,
+    HasTraits, String, Dict, Str, Float, Property, TraitType, TraitError,
     cached_property
 )
 
@@ -50,7 +50,7 @@ class Dimensions(HasTraits):
 
     # a dictionary holding dimension names and quantities
     # this should be frozen if you want to hash - don't change it
-    dimension_dict = DictStrFloat
+    dimension_dict = Dict(Str, Float)
 
     # the quantity type as an expression in powers of base dimensions
     expansion = Property(String, depends_on='dimension_dict')

--- a/scimath/units/quantity_traits.py
+++ b/scimath/units/quantity_traits.py
@@ -23,7 +23,7 @@
 
 from __future__ import absolute_import
 from traits.etsconfig.api import ETSConfig
-from traits.api import TraitHandler, Instance, true, Trait, Str
+from traits.api import TraitHandler, Instance, Bool, Trait, Str
 from traitsui.editor_factory import EditorFactory
 from scimath.units.unit_manager import unit_manager
 from scimath.units.quantity import Quantity
@@ -106,7 +106,7 @@ class ToolkitEditorFactory(EditorFactory):
     family_name = Str
     display_units = Instance(unit)
 
-    auto_set = true
+    auto_set = Bool(True)
 
     def init(self, *args):
         pass


### PR DESCRIPTION
This PR replaces the uses of the convenience trait types "false" and "DictStrFloat" with "Bool(False)" and "Dict(Str, Float)" respectively.