### PR TITLE
docs: fix typos

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -69,7 +69,7 @@ installed by `pip`).
 
 Other changes to commands should be a straightforward change to the listed
 commands for each task. See the EDM documentation for more information about
-how to run commands within an EDM enviornment.
+how to run commands within an EDM environment.
 
 """
 

--- a/scimath/units/has_units.py
+++ b/scimath/units/has_units.py
@@ -60,7 +60,7 @@ def simple_parser(lines):
 def has_units(func=None, summary='', doc='', inputs=None, outputs=None):
     r"""Function decorator: Wrap a standard python function for unit
     conversion. Note that conversion arguments must be supplied through
-    the decorator aguments or in a formatted docstring as shown below.
+    the decorator arguments or in a formatted docstring as shown below.
 
         Parameters
         ----------

--- a/scimath/units/unit_manager.py
+++ b/scimath/units/unit_manager.py
@@ -282,7 +282,7 @@ class UnitManager(HasPrivateTraits):
 
         if name == '':
             # No match yet...
-            # Try to more agressively match by checking for * and ? matches
+            # Try to more aggressively match by checking for * and ? matches
             for itm in self._wildcards:
                 if fnmatch(orig_name, itm):
                     name = itm

--- a/scimath/units/unit_manipulation.py
+++ b/scimath/units/unit_manipulation.py
@@ -11,7 +11,7 @@
     of ft/s).  convert_units() does this as well as adding units to non-united
     objects.  On output, it is common to want to take objects that may not
     have units associated with them and convert them to a 'united' object
-    that has units assoicated with them set_units() does this.
+    that has units associated with them set_units() does this.
 """
 
 # Numeric library imports
@@ -21,7 +21,7 @@ from numpy import ndarray
 # Enthought library imports
 import scimath.units as units
 
-# Numerical modeling libary imports
+# Numerical modeling library imports
 from scimath.units.unit_array import UnitArray
 from scimath.units.unit_scalar import UnitScalar
 from six.moves import zip

--- a/scimath/units/unit_system.py
+++ b/scimath/units/unit_system.py
@@ -40,7 +40,7 @@ class UnitSystem(HasTraits):
     families.  This is initially populated from the columns in the
     scimath/units/data/unit_families.txt file (by the unit_manager).
 
-    The common unit sytems are likely named 'KGS', 'IMPERIAL' etc.
+    The common unit systems are likely named 'KGS', 'IMPERIAL' etc.
     """
 
     # Unit System Traits


### PR DESCRIPTION
Hello,

This PR will fix : 

- 1 typo in `etstool.py`
- 1 typo in `scimath/units/has_units.py`
- 1 typo in `scimath/units/unit_manager.py`
- 2 typos in `scimath/units/unit_manipulation.py`
- 1 typo in `scimath/units/unit_system.py`



Bye! :robot: