### PR TITLE
Remove unnecessary "if __name__ == '__main__'" code blocks

### DIFF
--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -69,7 +69,3 @@ class Test(unittest.TestCase):
                              [0, 1, 2, 3, 4],
                              [0, 1, 2, 3, 4],
                              [0, 1, 2, 3, 4]])
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/scimath/units/tests/test_available_imports.py
+++ b/scimath/units/tests/test_available_imports.py
@@ -56,6 +56,3 @@ class GeoUnitsImportsTestCase(unittest.TestCase):
 
         for name in geo_imports:
             self.assertIn(name, available_now, msg=write_geo_err_msg(name))
-
-if __name__ == '__main__':
-    unittest.main()

--- a/scimath/units/tests/test_function_signature.py
+++ b/scimath/units/tests/test_function_signature.py
@@ -184,6 +184,3 @@ class FunctionSignatureTestCase(unittest.TestCase):
         self.assertEquals(
             def_signature(args_and_kwds),
             "def args_and_kwds(x, z=1, y=2):")
-
-if __name__ == '__main__':
-    unittest.main()

--- a/scimath/units/tests/test_has_units.py
+++ b/scimath/units/tests/test_has_units.py
@@ -417,17 +417,3 @@ class HasUnitsDecoratorTestCase(unittest.TestCase):
         self.assertTrue(isinstance(z, UnitScalar))
         self.assertEquals(z.units, meters)
         assert_array_almost_equal(z, 0.0)
-
-if __name__ == '__main__':
-    # profile the test suite.
-    import hotshot
-    import hotshot.stats
-    prof = hotshot.Profile("convert.prof")
-    prof.runcall(unittest.main)
-    prof.close()
-    stats = hotshot.stats.load("convert.prof")
-    stats.strip_dirs()
-    stats.sort_stats('time', 'calls')
-    stats.print_stats(20)
-    #import sys
-    # unittest.main(argv=sys.argv)

--- a/scimath/units/tests/test_scalar_unit.py
+++ b/scimath/units/tests/test_scalar_unit.py
@@ -61,18 +61,3 @@ class UnitScalarTest(unittest.TestCase):
         dimensionless_unit.label = "Cool unit"
         a = UnitScalar(1, units=dimensionless_unit)
         self.assertEqual(str(a), "UnitScalar (Cool unit): 1")
-
-
-def test_offset_unit_computations():
-    """ Executing some basic computations with a basic custom unit with offset.
-    """
-    my_u = unit(12, m.derivation, 14)
-    s1 = UnitScalar(3, units=my_u)
-    s2 = UnitScalar(5, units=my_u)
-    s3 = s1 + s2
-    assert_equal(s3, UnitScalar(8, units=my_u))
-
-
-if __name__ == '__main__':
-    import sys
-    unittest.main(argv=sys.argv)

--- a/scimath/units/tests/test_unit_array.py
+++ b/scimath/units/tests/test_unit_array.py
@@ -468,7 +468,3 @@ class PassUnitsTestCase(unittest.TestCase):
         self.assertEqual(result[0], True)
         self.assertEqual(result[1], False)
         self.assertEqual(result[2], True)
-
-if __name__ == '__main__':
-    import sys
-    unittest.main(argv=sys.argv)

--- a/scimath/units/tests/test_unit_manipulation.py
+++ b/scimath/units/tests/test_unit_manipulation.py
@@ -373,7 +373,3 @@ class StripUnitsTestCase(unittest.TestCase):
         self.assertEquals(len(outs), 4)
         for x in outs:
             self.assertFalse(isinstance(x, (UnitArray, UnitScalar)))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/scimath/units/unit_db.py
+++ b/scimath/units/unit_db.py
@@ -312,29 +312,3 @@ def cvt_unit(unit_label):
     """ Parse a unit description """
     units = unit_parser.parse_unit(unit_label)
     return units
-
-
-# Allow one-off smoke test if this file is executed stand-alone
-if __name__ == '__main__':
-
-    # Setup profiling if we can
-    try:
-        import enthought.gotcha as gotcha
-        gotcha.begin_profiling()
-
-        from scimath.units import unit_db
-
-        udb = gotcha.profile(unit_db.UnitDB)
-        print('Getting family members...')
-        gotcha.profile(udb.get_family_members_from_file)
-        print('Getting unit families...')
-        gotcha.profile(udb.get_unit_families_from_file)
-        print('Systems: %s' % udb.unit_systems)
-        print('Families: %s' % len(udb.preferred_names))
-        print('Members: %s' % len(udb.member_names))
-
-        gotcha.end_profiling()
-    except ImportError:
-        print('Unable to provide a profile -- enthought.gotcha not found.')
-
-        from scimath.units import unit_db


### PR DESCRIPTION
This PR remove unnecessary `if __name__ == "__main__"` blocks from the codebase - most of which are `unittest` related.

Note that there are also instances of potentially broken code in the blocks e.g. importing `hotshot` package or importing `enthought.gotcha`.