### PR TITLE
Remove all use of six

### DIFF
--- a/scimath/interpolate/interpolate.py
+++ b/scimath/interpolate/interpolate.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import numpy
 
 from . import _interpolate
-from six.moves import range
 
 
 def make_array_safe(ary, typecode):

--- a/scimath/mathematics/quaternion.py
+++ b/scimath/mathematics/quaternion.py
@@ -14,7 +14,6 @@
 # Major library imports.
 from __future__ import absolute_import
 import numpy as np
-from six.moves import map
 
 
 def normq(quat):

--- a/scimath/physical_quantities/dimensions.py
+++ b/scimath/physical_quantities/dimensions.py
@@ -28,7 +28,6 @@ from traits.api import (
 
 # local imports
 from .util import dict_mul, dict_add, dict_sub, format_expansion
-import six
 
 
 class Dimensions(HasTraits):
@@ -125,7 +124,7 @@ class Dimensions(HasTraits):
             raise NotImplementedError
 
     def __pow__(self, other):
-        if isinstance(other, (float,) + six.integer_types):
+        if isinstance(other, (float,) + int):
             return Dimensions(dict_mul(self.dimension_dict, other))
         else:
             raise NotImplementedError
@@ -140,7 +139,7 @@ class Dim(TraitType):
             return value
         if isinstance(value, dict):
             return Dimensions(value)
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             try:
                 return Dimensions.from_expansion(value)
             except InvalidExpansionError:

--- a/scimath/physical_quantities/dimensions.py
+++ b/scimath/physical_quantities/dimensions.py
@@ -124,7 +124,7 @@ class Dimensions(HasTraits):
             raise NotImplementedError
 
     def __pow__(self, other):
-        if isinstance(other, (float,) + int):
+        if isinstance(other, (float, int)):
             return Dimensions(dict_mul(self.dimension_dict, other))
         else:
             raise NotImplementedError

--- a/scimath/physical_quantities/units.py
+++ b/scimath/physical_quantities/units.py
@@ -150,13 +150,13 @@ class Unit(HasTraits):
                      self.scale, self.offset, self.logarithmic, self.log_base))
 
     def __mul__(self, other):
-        if isinstance(other, (float,) + int + array):
+        if isinstance(other, (float, int, array)):
             return Quantity(magnitude=other, units=self)
         else:
             raise NotImplementedError
 
     def __rmul__(self, other):
-        if isinstance(other, (float,) + int + array):
+        if isinstance(other, (float, int, array)):
             return Quantity(magnitude=other, units=self)
         else:
             raise NotImplementedError
@@ -165,7 +165,7 @@ class Unit(HasTraits):
         return type(self).__truediv__(self, other)
 
     def __truediv__(self, other):
-        if isinstance(other, (float,) + int + array):
+        if isinstance(other, (float, int, array)):
             return Quantity(magnitude=1.0/other, units=self)
         else:
             raise NotImplementedError
@@ -221,7 +221,7 @@ class MultiplicativeUnit(Unit):
             raise NotImplementedError
 
     def __pow__(self, other):
-        if isinstance(other, (float,) + int):
+        if isinstance(other, (float, int)):
             return DerivedUnit(derivation=dict_mul(self.derivation,
                                                    other.derivation),
                                scale=self.scale**other)

--- a/scimath/physical_quantities/units.py
+++ b/scimath/physical_quantities/units.py
@@ -5,7 +5,6 @@ from __future__ import division
 
 from __future__ import absolute_import
 from numpy import array, log10
-import six
 
 from traits.api import HasTraits, Float, String, Unicode, Bool, \
     Dict, Any, Instance, Property, cached_property
@@ -151,13 +150,13 @@ class Unit(HasTraits):
                      self.scale, self.offset, self.logarithmic, self.log_base))
 
     def __mul__(self, other):
-        if isinstance(other, (float,) + six.integer_types + array):
+        if isinstance(other, (float,) + int + array):
             return Quantity(magnitude=other, units=self)
         else:
             raise NotImplementedError
 
     def __rmul__(self, other):
-        if isinstance(other, (float,) + six.integer_types + array):
+        if isinstance(other, (float,) + int + array):
             return Quantity(magnitude=other, units=self)
         else:
             raise NotImplementedError
@@ -166,7 +165,7 @@ class Unit(HasTraits):
         return type(self).__truediv__(self, other)
 
     def __truediv__(self, other):
-        if isinstance(other, (float,) + six.integer_types + array):
+        if isinstance(other, (float,) + int + array):
             return Quantity(magnitude=1.0/other, units=self)
         else:
             raise NotImplementedError
@@ -222,7 +221,7 @@ class MultiplicativeUnit(Unit):
             raise NotImplementedError
 
     def __pow__(self, other):
-        if isinstance(other, (float,) + six.integer_types):
+        if isinstance(other, (float,) + int):
             return DerivedUnit(derivation=dict_mul(self.derivation,
                                                    other.derivation),
                                scale=self.scale**other)

--- a/scimath/units/function_signature.py
+++ b/scimath/units/function_signature.py
@@ -3,7 +3,6 @@
 """
 
 from __future__ import absolute_import
-from six.moves import zip
 
 
 def function_arguments(func):

--- a/scimath/units/quantity.py
+++ b/scimath/units/quantity.py
@@ -31,7 +31,6 @@ from scimath.units.smart_unit import SmartUnit
 from scimath.units.unit_parser import unit_parser
 from scimath.units.unit_manager import unit_manager
 from scimath.units.family_name_trait import FamilyNameTrait
-import six
 
 
 # Setup a logger for this module.
@@ -119,7 +118,7 @@ class Quantity(HasPrivateTraits):
 
         # Allow for parsing a unit string as the units argument
         else:
-            if isinstance(units, six.string_types):
+            if isinstance(units, str):
                 units = unit_parser.parse_unit(units, suppress_warnings=False)
 
         if 'family_name' not in traits:
@@ -347,7 +346,7 @@ class Quantity(HasPrivateTraits):
         if isinstance(data, Quantity):
             # if data is a string or an array of strings, ignore the conversion
             # because convert will fail for string data
-            if isinstance(data.data, six.string_types):
+            if isinstance(data.data, str):
                 converted_data = data.data
             elif isinstance(data.data, numpy.ndarray) \
                     and data.data.dtype.char == 'S':

--- a/scimath/units/tests/test_unit_array.py
+++ b/scimath/units/tests/test_unit_array.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from copy import copy
-from six.moves.cPickle import dumps, loads
+from pickle import dumps, loads
 import timeit
 import unittest
 import operator

--- a/scimath/units/unit.py
+++ b/scimath/units/unit.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 import operator
 
 import numpy
-from six.moves import map
 
 
 class unit(object):

--- a/scimath/units/unit_array.py
+++ b/scimath/units/unit_array.py
@@ -6,7 +6,6 @@ import numpy
 from scimath.units import convert
 from scimath.units.unit import unit, dimensionless, IncompatibleUnits
 from scimath.units.unit_parser import unit_parser
-import six
 
 
 def __newobj__(cls, *args):
@@ -157,7 +156,7 @@ class UnitArray(numpy.ndarray):
                                         buffer=arr)
 
         ### Configure Other Attributes ########################################
-        if isinstance(units, six.string_types):
+        if isinstance(units, str):
             units = unit_parser.parse_unit(units)
 
         res.units = units

--- a/scimath/units/unit_db.py
+++ b/scimath/units/unit_db.py
@@ -26,7 +26,6 @@ from traits.util.resource import get_path
 
 # Local Imports:
 from scimath.units.unit_parser import unit_parser
-from six.moves import map
 
 
 logger = logging.getLogger(__name__)

--- a/scimath/units/unit_manager.py
+++ b/scimath/units/unit_manager.py
@@ -36,7 +36,6 @@ from scimath.units.unit_converter import default_unit_converters
 from scimath.units.convert import convert as unit_convert
 from .unit import unit
 from .unit_parser import unit_parser
-import six
 
 
 logger = logging.getLogger(__name__)
@@ -168,7 +167,7 @@ class UnitManager(HasPrivateTraits):
         Probably called when the project is loaded.
 
         """
-        if isinstance(system, six.string_types):
+        if isinstance(system, str):
             self.default_system = self.lookup_system(system.upper())
 
         elif isinstance(system, UnitSystem):
@@ -210,7 +209,7 @@ class UnitManager(HasPrivateTraits):
             if isinstance(system, UnitSystem):
                 result = system
             # case #2 - system specified as a string eg 'IMPERIAL'
-            elif isinstance(system, six.string_types):
+            elif isinstance(system, str):
                 result = self.lookup_system(system.upper())
             # case #3 - no system supplied so use the unit_manager's default
             elif system is None:
@@ -368,7 +367,7 @@ class UnitManager(HasPrivateTraits):
         elif isinstance(units, unit):
             units_label = units.label
 
-        elif isinstance(units, six.string_types):
+        elif isinstance(units, str):
             units_label = units
             units = unit_parser.parse_unit(units)
 
@@ -479,7 +478,7 @@ class UnitManager(HasPrivateTraits):
     # TODO: this method does not seem to ever be called--consider deleting.
     def _convert(self, value, from_units, to_units):
 
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             converted_data = value.data
         elif isinstance( value, numpy.ndarray) and \
                 value.dtype.char == 'S':

--- a/scimath/units/unit_manipulation.py
+++ b/scimath/units/unit_manipulation.py
@@ -24,7 +24,6 @@ import scimath.units as units
 # Numerical modeling library imports
 from scimath.units.unit_array import UnitArray
 from scimath.units.unit_scalar import UnitScalar
-from six.moves import zip
 
 
 def manipulate_units(units, converters, *args):


### PR DESCRIPTION
This PR removes all use of `six` from the codebase.  I suspect CI will fail (hopefully at least) until we stop testing on Python 2.  We can either do that on #104, a standalone PR, or it can be added here. 