### PR TITLE
Stop testing on Python 2.7 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=2.7
-    - env: RUNTIME=3.5
     - env: RUNTIME=3.6
   fast_finish: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,6 @@ environment:
 
   matrix:
 
-    - RUNTIME: '2.7'
-    - RUNTIME: '3.5'
     - RUNTIME: '3.6'
 
 matrix:

--- a/etstool.py
+++ b/etstool.py
@@ -54,7 +54,7 @@ using::
 
     python etstool.py test_all
 
-Currently supported runtime values are ``2.7`` and ``3.5``.
+Currently supported runtime values are ``3.6``.
 
 Tests can still be run via the usual means in other environments if that suits
 a developer's purpose.
@@ -84,7 +84,7 @@ from contextlib import contextmanager
 
 import click
 
-supported_runtimes = ['2.7', '3.5', '3.6']
+supported_runtimes = ['3.6']
 
 dependencies = {
     "numpy",


### PR DESCRIPTION
We only support Python >= 3.6 now.