### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -1,0 +1,37 @@
+name: Test with EDM
+
+on:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * 5'
+
+env:
+  INSTALL_EDM_VERSION: 3.2.3
+
+jobs:
+
+  # Test against EDM packages
+  test-with-edm:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache EDM packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache
+          key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
+      - name: Set up EDM
+        uses: enthought/setup-edm-action@v1
+        with:
+          edm-version: ${{ env.INSTALL_EDM_VERSION }}
+      - name: Install click to the default EDM environment
+        run: edm install -y wheel click coverage
+      - name: Install test environment
+        run: edm run -- python etstool.py install
+      - name: Run tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: edm run -- python etstool.py test


### PR DESCRIPTION
This PR runs the test suite on github actions.  I made the work flow both a cron job and run on every PR.  Perhaps we should have a separate PR testing against traits from source, and maybe with latest scipy from pip? (scimath only has 2 dependencies - traits and scipy).
I think I will defer those two potential additional cron jobs to a follow up PR once we decide if they are worth it.