### PR TITLE
Remove an unused variable

### DIFF
--- a/scimath/interpolate/interpolate.h
+++ b/scimath/interpolate/interpolate.h
@@ -110,7 +110,6 @@ int block_average_above(T* x_vec, T* y_vec, int len,
             T thickness_sum = thickness;  
             for(int j=start_index; j<=index; j++)
             {
-                    T next_x;
                     if (x_vec[j+1] < new_x)
                         thickness = x_vec[j+1] - x_vec[j];
                     else


### PR DESCRIPTION
This PR removes an unused variable and so silences a compile-time warning from clang:

```
    clang++: scimath/interpolate/_interpolate.cpp
    In file included from scimath/interpolate/_interpolate.cpp:4:
    scimath/interpolate/interpolate.h:113:23: warning: unused variable 'next_x' [-Wunused-variable]
                        T next_x;
                          ^
    scimath/interpolate/_interpolate.cpp:227:5: note: in instantiation of function template specialization 'block_average_above<double>' requested here
        block_average_above((double*)PyArray_DATA((PyArrayObject*)arr_x),
        ^
    1 warning generated.
```