### PR TITLE
Remove "__id__" and "End of file" markers in `scimath.units.*`

### DIFF
--- a/scimath/units/SI.py
+++ b/scimath/units/SI.py
@@ -111,10 +111,3 @@ femto = 1e-15
 atto = 1e-18
 zepto = 1e-21
 yocto = 1e-24
-
-
-# version
-__id__ = "$Id: SI.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/area.py
+++ b/scimath/units/area.py
@@ -34,9 +34,3 @@ barn = 1e-28 * square_meter
 b = barn
 bn = barn
 barns = barn
-
-# version
-__id__ = "$Id: area.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/energy.py
+++ b/scimath/units/energy.py
@@ -52,10 +52,3 @@ GeV = giga * eV
 
 cal = calorie
 kcal = kilo * calorie
-
-
-# version
-__id__ = "$Id: energy.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/power.py
+++ b/scimath/units/power.py
@@ -21,10 +21,3 @@ from .SI import watt, kilo
 kilowatt = kilo * watt
 kw = kilowatt
 horsepower = 745.7 * watt
-
-
-# version
-__id__ = "$Id: power.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/pressure.py
+++ b/scimath/units/pressure.py
@@ -74,9 +74,3 @@ psig = unit(psi.value, psi.derivation, 14.6959494)
 
 inHg = 3386.389 * pascal
 inHg.label = 'inHg'
-
-# version
-__id__ = "$Id: pressure.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/substance.py
+++ b/scimath/units/substance.py
@@ -18,10 +18,3 @@ from .SI import mole, kilo
 
 mol = mole
 kmol = kilo * mole
-
-
-# version
-__id__ = "$Id: substance.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/temperature.py
+++ b/scimath/units/temperature.py
@@ -35,9 +35,3 @@ degF = fahrenheit
 degf = fahrenheit
 degK = kelvin
 degk = kelvin
-
-# version
-__id__ = "$Id: temperature.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file

--- a/scimath/units/unit.py
+++ b/scimath/units/unit.py
@@ -267,9 +267,3 @@ def is_dimensionless(unit):
         return True
 
     return False
-
-# version
-__id__ = "$Id: unit.py,v 1.1.1.1 2003/07/02 21:39:14 aivazis Exp $"
-
-#
-# End of file


### PR DESCRIPTION
Some of the modules in the `scimath.units` subpackage contain a constant `__id__` - which have been removed in this PR. Along with that, there were more "End of file" markers, which have also been removed.