### PR TITLE
Remove "scimath.units.units_version"

### DIFF
--- a/scimath/units/units_version.py
+++ b/scimath/units/units_version.py
@@ -1,6 +1,0 @@
-major = 3
-minor = 0
-micro = 0
-release_level = 'a1'
-
-units_version = '%(major)d.%(minor)d.%(micro)d_%(release_level)s' % (locals())


### PR DESCRIPTION
We dont need the `scimath.units.units_version` module anymore as `scimath` is versioned as a whole now. This seems to be a
relic from the days of the `enthought.*` namespace package.