### PR TITLE
Use unittest to discover and run the testsuite instead of nose

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -90,7 +90,6 @@ dependencies = {
     "numpy",
     "scipy",
     "traits",
-    "nose",
     "coverage",
 }
 

--- a/etstool.py
+++ b/etstool.py
@@ -157,7 +157,7 @@ def test(runtime, environment):
     environ['PYTHONUNBUFFERED'] = "1"
 
     commands = [
-        "edm run -e {environment} -- coverage run -p -m nose.core -v scimath --nologcapture"
+        "edm run -e {environment} -- coverage run -p -m unittest discover -v scimath"
     ]
 
     # We run in a tempdir to avoid accidentally picking up wrong scimath

--- a/scimath/units/tests/test_dimensionless_units.py
+++ b/scimath/units/tests/test_dimensionless_units.py
@@ -1,24 +1,27 @@
+import unittest
+
 from numpy.testing import assert_equal
 from scimath.units.unit_scalar import UnitScalar
 from scimath.units.unit import dimensionless
 
 
-def dimensionless_test():
-    """
-    Test the modification to the division, multiplication and pow
-    such that a dimensionless quantity formed by is indeed dimensionless
-    """
+class DimensionlessTestCase(unittest.TestCase):
+    def dimensionless_test(self):
+        """
+        Test the modification to the division, multiplication and pow
+        such that a dimensionless quantity formed by is indeed dimensionless
+        """
 
-    a = UnitScalar(1.0, units='m')
-    b = UnitScalar(2.0, units='mm')
-    d = UnitScalar(2.0, units='m**(-1)')
+        a = UnitScalar(1.0, units='m')
+        b = UnitScalar(2.0, units='mm')
+        d = UnitScalar(2.0, units='m**(-1)')
 
-    c = a / b
-    e = b * d
+        c = a / b
+        e = b * d
 
-    f = UnitScalar(2.0, units=dimensionless)
-    g = f**2
+        f = UnitScalar(2.0, units=dimensionless)
+        g = f**2
 
-    assert_equal(c.units, dimensionless)
-    assert_equal(e.units, dimensionless)
-    assert_equal(g.units, dimensionless)
+        assert_equal(c.units, dimensionless)
+        assert_equal(e.units, dimensionless)
+        assert_equal(g.units, dimensionless)

--- a/scimath/units/tests/test_dimensionless_units.py
+++ b/scimath/units/tests/test_dimensionless_units.py
@@ -6,7 +6,7 @@ from scimath.units.unit import dimensionless
 
 
 class DimensionlessTestCase(unittest.TestCase):
-    def dimensionless_test(self):
+    def test_dimensionless(self):
         """
         Test the modification to the division, multiplication and pow
         such that a dimensionless quantity formed by is indeed dimensionless

--- a/scimath/units/tests/test_scalar_unit.py
+++ b/scimath/units/tests/test_scalar_unit.py
@@ -10,9 +10,6 @@ from scimath.units.length import m, cm
 from scimath.units.unit import unit
 
 
-from nose.tools import assert_equal, assert_is_instance
-
-
 class UnitScalarDocTestCase(doctest_for_module(unit_scalar)):
     pass
 


### PR DESCRIPTION
This PR does the following : 

- Convert a test function `dimensionless_test` into a test method in a `unittest.TestCase` class
- Rename the test method to start with `test_` instead of ending with `_test` to ensure that it gets picked up during unittest test discovery
- Remove unused nose imports
- Use `unittest discover` instead of nose to discover and run the testsuite
- Remove `nose` as a dependency in  the etstool utility