### PR TITLE
Address unittest-related deprecations

### DIFF
--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -10,7 +10,7 @@ from scimath.interpolate.api import linear, block_average_above
 class Test(unittest.TestCase):
 
     def assertAllclose(self, x, y):
-        self.assert_(allclose(x, y))
+        self.assertTrue(allclose(x, y))
 
     def test_linear(self):
         N = 3000

--- a/scimath/units/tests/test_function_signature.py
+++ b/scimath/units/tests/test_function_signature.py
@@ -174,12 +174,12 @@ def args_and_kwds(x, z=1, y=2):
 class FunctionSignatureTestCase(unittest.TestCase):
 
     def test_just_args(self):
-        self.assertEquals(def_signature(just_args), "def just_args(x, y):")
+        self.assertEqual(def_signature(just_args), "def just_args(x, y):")
 
     def test_just_kwds(self):
-        self.assertEquals(def_signature(just_kwds), "def just_kwds(y=1, x=2):")
+        self.assertEqual(def_signature(just_kwds), "def just_kwds(y=1, x=2):")
 
     def test_args_and_kwds(self):
-        self.assertEquals(
+        self.assertEqual(
             def_signature(args_and_kwds),
             "def args_and_kwds(x, z=1, y=2):")

--- a/scimath/units/tests/test_has_units.py
+++ b/scimath/units/tests/test_has_units.py
@@ -340,79 +340,79 @@ class HasUnitsDecoratorTestCase(unittest.TestCase):
         unittest.TestCase.setUp(self)
 
     def test_decorator_plays_nice(self):
-        self.assertEquals(foo_with_units.__module__, foo.__module__)
-        self.assertEquals(foo_with_units.__doc__, foo.__doc__)
-        self.assertEquals(foo_with_units.__name__, foo.__name__)
+        self.assertEqual(foo_with_units.__module__, foo.__module__)
+        self.assertEqual(foo_with_units.__doc__, foo.__doc__)
+        self.assertEqual(foo_with_units.__name__, foo.__name__)
 
     def test_input_variables_parsed(self):
         inputs = foo_with_units.inputs
-        self.assertEquals(len(inputs), 2)
-        self.assertEquals(inputs[0].name, 'x')
-        self.assertEquals(inputs[0].units, meters)
-        self.assertEquals(inputs[1].name, 'y')
-        self.assertEquals(inputs[1].units, second)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs[0].name, 'x')
+        self.assertEqual(inputs[0].units, meters)
+        self.assertEqual(inputs[1].name, 'y')
+        self.assertEqual(inputs[1].units, second)
 
     def test_output_variables_parsed(self):
         outputs = foo_with_units.outputs
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(outputs[0].name, 'z')
-        self.assertEquals(outputs[0].units, meters / second)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].name, 'z')
+        self.assertEqual(outputs[0].units, meters / second)
 
     def test_no_internal_units_array(self):
         z = foo_with_units(self.meter_array, self.second_array)
         self.assertTrue(isinstance(z, UnitArray))
-        self.assertEquals(z.units, meters / second)
+        self.assertEqual(z.units, meters / second)
 
     def test_no_internal_units_scalar(self):
         z = foo_with_units(self.meter_scalar, self.second_scalar)
         self.assertTrue(isinstance(z, UnitScalar))
-        self.assertEquals(z.units, meters / second)
+        self.assertEqual(z.units, meters / second)
 
     def test_feet(self):
         z = foo_with_units(self.feet_array, self.second_array)
         self.assertTrue(isinstance(z, UnitArray))
-        self.assertEquals(z.units, meters / second)
+        self.assertEqual(z.units, meters / second)
         assert_array_almost_equal(z, numpy.array([0.4064, 0.762, 1.8288]))
         z = foo_with_units(self.feet_scalar, self.second_scalar)
         self.assertTrue(isinstance(z, UnitScalar))
-        self.assertEquals(z.units, meters / second)
+        self.assertEqual(z.units, meters / second)
         assert_array_almost_equal(z, 0.4064)
 
     def test_v_decorator_plays_nice(self):
-        self.assertEquals(vec_bar_with_units.__module__, bar.__module__)
-        self.assertEquals(vec_bar_with_units.__doc__, bar.__doc__)
-        self.assertEquals(vec_bar_with_units.__name__, bar.__name__)
+        self.assertEqual(vec_bar_with_units.__module__, bar.__module__)
+        self.assertEqual(vec_bar_with_units.__doc__, bar.__doc__)
+        self.assertEqual(vec_bar_with_units.__name__, bar.__name__)
 
     def test_v_input_variables_parsed(self):
         inputs = vec_bar_with_units.inputs
-        self.assertEquals(len(inputs), 2)
-        self.assertEquals(inputs[0].name, 'x')
-        self.assertEquals(inputs[0].units, meters)
-        self.assertEquals(inputs[1].name, 'y')
-        self.assertEquals(inputs[1].units, second)
+        self.assertEqual(len(inputs), 2)
+        self.assertEqual(inputs[0].name, 'x')
+        self.assertEqual(inputs[0].units, meters)
+        self.assertEqual(inputs[1].name, 'y')
+        self.assertEqual(inputs[1].units, second)
 
     def test_v_output_variables_parsed(self):
         outputs = vec_bar_with_units.outputs
-        self.assertEquals(len(outputs), 1)
-        self.assertEquals(outputs[0].name, 'z')
-        self.assertEquals(outputs[0].units, meters)
+        self.assertEqual(len(outputs), 1)
+        self.assertEqual(outputs[0].name, 'z')
+        self.assertEqual(outputs[0].units, meters)
 
     def test_v_no_internal_units_array(self):
         z = vec_bar_with_units(self.meter_array, self.second_array)
         self.assertTrue(isinstance(z, UnitArray))
-        self.assertEquals(z.units, meters)
+        self.assertEqual(z.units, meters)
 
     def test_v_no_internal_units_scalar(self):
         z = vec_bar_with_units(self.meter_scalar, self.second_scalar)
         self.assertTrue(isinstance(z, UnitScalar))
-        self.assertEquals(z.units, meters)
+        self.assertEqual(z.units, meters)
 
     def test_v_feet(self):
         z = vec_bar_with_units(self.feet_array, self.second_array)
         self.assertTrue(isinstance(z, UnitArray))
-        self.assertEquals(z.units, meters)
+        self.assertEqual(z.units, meters)
         assert_array_almost_equal(z, numpy.array([0.0, 0.0, 3.6576]))
         z = vec_bar_with_units(self.feet_scalar, self.second_scalar)
         self.assertTrue(isinstance(z, UnitScalar))
-        self.assertEquals(z.units, meters)
+        self.assertEqual(z.units, meters)
         assert_array_almost_equal(z, 0.0)

--- a/scimath/units/tests/test_has_units.py
+++ b/scimath/units/tests/test_has_units.py
@@ -33,7 +33,7 @@ class HasUnitsTestCase(unittest.TestCase):
     def tearDown(self):
         unittest.TestCase.tearDown(self)
 
-    def failUnlessEqual(self, first, second, msg=None):
+    def assertEqual(self, first, second, msg=None):
         """Fail if the two objects are unequal as determined by the '=='
            operator.
 
@@ -41,8 +41,6 @@ class HasUnitsTestCase(unittest.TestCase):
         """
         if not all(first == second):
             raise self.failureException(msg or '%r != %r' % (first, second))
-
-    assertEqual = failUnlessEqual
 
     ##########################################################################
     # HasUnitsTestCase interface.

--- a/scimath/units/tests/test_meta_quantity.py
+++ b/scimath/units/tests/test_meta_quantity.py
@@ -19,9 +19,9 @@ class TraitsTestCase(TestCase):
     def test_metaquantity(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
 
-        self.failUnlessEqual(mq.name, 'vp')
-        self.failUnlessEqual(mq.units.label, 'km/s')
-        self.failUnlessEqual(mq.family_name, 'pvelocity')
+        self.assertEqual(mq.name, 'vp')
+        self.assertEqual(mq.units.label, 'km/s')
+        self.assertEqual(mq.family_name, 'pvelocity')
         return
 
     def test_metaquantity_compatible_family_change(self):
@@ -29,18 +29,18 @@ class TraitsTestCase(TestCase):
 
         mq.name = 'vs'
         mq.family_name = 'svelocity'
-        self.failUnlessEqual(mq.name, 'vs')
-        self.failUnlessEqual(mq.units.label, 'km/s')
-        self.failUnlessEqual(mq.family_name, 'svelocity')
+        self.assertEqual(mq.name, 'vs')
+        self.assertEqual(mq.units.label, 'km/s')
+        self.assertEqual(mq.family_name, 'svelocity')
         return
 
     def test_metaquantity_compatible_units_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
 
         mq.units = 'ft/s'
-        self.failUnlessEqual(mq.name, 'vp')
-        self.failUnlessEqual(mq.units.label, 'ft/s')
-        self.failUnlessEqual(mq.family_name, 'pvelocity')
+        self.assertEqual(mq.name, 'vp')
+        self.assertEqual(mq.units.label, 'ft/s')
+        self.assertEqual(mq.family_name, 'pvelocity')
         return
 
     def test_metaquantity_incompatible_units_change(self):
@@ -48,9 +48,9 @@ class TraitsTestCase(TestCase):
 
         self.failUnlessRaises(TraitError, setattr, mq, 'units', 'hours')
 
-        self.failUnlessEqual(mq.name, 'vp')
-        self.failUnlessEqual(mq.units.label, 'km/s')
-        self.failUnlessEqual(mq.family_name, 'pvelocity')
+        self.assertEqual(mq.name, 'vp')
+        self.assertEqual(mq.units.label, 'km/s')
+        self.assertEqual(mq.family_name, 'pvelocity')
         return
 
     def test_metaquantity_incompatible_family_change(self):
@@ -58,9 +58,9 @@ class TraitsTestCase(TestCase):
 
         mq.family_name = 'time'
 
-        self.failUnlessEqual(mq.name, 'vp')
-        self.failUnlessEqual(mq.units.label, 'msec')
-        self.failUnlessEqual(mq.family_name, 'time')
+        self.assertEqual(mq.name, 'vp')
+        self.assertEqual(mq.units.label, 'msec')
+        self.assertEqual(mq.family_name, 'time')
         return
 
     def ui_simple(self):

--- a/scimath/units/tests/test_meta_quantity.py
+++ b/scimath/units/tests/test_meta_quantity.py
@@ -46,7 +46,7 @@ class TraitsTestCase(TestCase):
     def test_metaquantity_incompatible_units_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
 
-        self.failUnlessRaises(TraitError, setattr, mq, 'units', 'hours')
+        self.assertRaises(TraitError, setattr, mq, 'units', 'hours')
 
         self.assertEqual(mq.name, 'vp')
         self.assertEqual(mq.units.label, 'km/s')

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -107,11 +107,8 @@ class TraitsTestCase(TestCase):
         obj = UnitsStrictNotNone(units='km')
         self.assertRaises(TraitError, setattr, obj, 'units', None)
 
-        try:
+        with self.assertRaises(TraitError):
             obj = UnitsStrictNotNone(units=None)
-            self.fail('Constructor did not raise TraitError with units=None')
-        except TraitError:
-            pass
         return
 
     def test_strict_units_trait(self):
@@ -199,12 +196,8 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameStrictNotNone(family_name='length')
         self.assertRaises(TraitError, setattr, obj, 'family_name', None)
 
-        try:
+        with self.assertRaises(TraitError):
             obj = FamilyNameStrictNotNone(family_name=None)
-            self.fail(
-                'Constructor did not raise TraitError with family_name=None')
-        except TraitError:
-            pass
         return
 
     def test_family_with_units_defaults(self):

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -99,7 +99,7 @@ class TraitsTestCase(TestCase):
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
-        self.failUnless(obj.units is units)
+        self.assertTrue(obj.units is units)
 
         return
 
@@ -136,7 +136,7 @@ class TraitsTestCase(TestCase):
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
-        self.failUnless(obj.units is units)
+        self.assertTrue(obj.units is units)
 
         return
 
@@ -171,7 +171,7 @@ class TraitsTestCase(TestCase):
 
         obj = FamilyNameNonStrict()
         self.assertFalse(obj is None)
-        self.failUnless(obj.family_name is None)
+        self.assertTrue(obj.family_name is None)
 
         return
 
@@ -191,7 +191,7 @@ class TraitsTestCase(TestCase):
 
         obj = FamilyNameNonStrict()
         self.assertFalse(obj is None)
-        self.failUnless(obj.family_name is None)
+        self.assertTrue(obj.family_name is None)
 
         return
 

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -81,20 +81,20 @@ class TraitsTestCase(TestCase):
 
     def test_units_trait(self):
         obj = UnitsNonStrict(units='km')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'km')
 
         obj.units = 'm/sec**2'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'm/sec**2')
 
         obj.units = 'invalid'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'invalid')
         self.assertEqual(obj.units.derivation, dimensionless.derivation)
 
         units = unit_parser.parse_unit('g/cc')
-        self.failIf(units is None)
+        self.assertFalse(units is None)
         self.assertEqual(units.label, 'g/cc')
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
@@ -116,22 +116,22 @@ class TraitsTestCase(TestCase):
 
     def test_strict_units_trait(self):
         obj = UnitsStrict(units='km')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'km')
 
         obj.units = 'm/sec**2'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'm/sec**2')
         self.assertEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
 
         self.assertRaises(TraitError, setattr, obj, 'units', 'invalid')
 
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'm/sec**2')
         self.assertEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
 
         units = unit_parser.parse_unit('g/cc')
-        self.failIf(units is None)
+        self.assertFalse(units is None)
         self.assertEqual(units.label, 'g/cc')
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
@@ -158,39 +158,39 @@ class TraitsTestCase(TestCase):
 
     def test_family_name_trait(self):
         obj = FamilyNameNonStrict(family_name='distance')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'distance')
 
         obj.family_name = 'time'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'time')
 
         obj.family_name = 'unknown to unit_manager'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'unknown to unit_manager')
 
         obj = FamilyNameNonStrict()
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.failUnless(obj.family_name is None)
 
         return
 
     def test_family_name_strict_trait(self):
         obj = FamilyNameStrict(family_name='distance')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'distance')
 
         obj.family_name = 'time'
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'time')
 
         self.assertRaises(TraitError, setattr, obj, 'family_name',
                           'unknown to unit_manager')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'time')
 
         obj = FamilyNameNonStrict()
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.failUnless(obj.family_name is None)
 
         return
@@ -210,7 +210,7 @@ class TraitsTestCase(TestCase):
     def test_family_with_units_defaults(self):
         obj = FamilyNameWithUnitsLinkage()
 
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.family_name, 'length')
         self.assertEqual(obj.units.label, 'm')
 
@@ -293,7 +293,7 @@ class TraitsTestCase(TestCase):
         self.event_change_log = []
 
         obj = UnitsNonStrict(units='km')
-        self.failIf(obj is None)
+        self.assertFalse(obj is None)
         self.assertEqual(obj.units.label, 'km')
 
         obj.on_trait_change(self._units_changed)

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -105,7 +105,7 @@ class TraitsTestCase(TestCase):
 
     def test_units_not_none(self):
         obj = UnitsStrictNotNone(units='km')
-        self.failUnlessRaises(TraitError, setattr, obj, 'units', None)
+        self.assertRaises(TraitError, setattr, obj, 'units', None)
 
         try:
             obj = UnitsStrictNotNone(units=None)
@@ -124,7 +124,7 @@ class TraitsTestCase(TestCase):
         self.assertEqual(obj.units.label, 'm/sec**2')
         self.assertEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
 
-        self.failUnlessRaises(TraitError, setattr, obj, 'units', 'invalid')
+        self.assertRaises(TraitError, setattr, obj, 'units', 'invalid')
 
         self.failIf(obj is None)
         self.assertEqual(obj.units.label, 'm/sec**2')
@@ -152,7 +152,7 @@ class TraitsTestCase(TestCase):
         obj.family_name = 'distance'
         obj.units = 'km'
 
-        self.failUnlessRaises(TraitError, setattr, obj, 'units', 'g/cc')
+        self.assertRaises(TraitError, setattr, obj, 'units', 'g/cc')
 
         return
 
@@ -184,8 +184,8 @@ class TraitsTestCase(TestCase):
         self.failIf(obj is None)
         self.assertEqual(obj.family_name, 'time')
 
-        self.failUnlessRaises(TraitError, setattr, obj, 'family_name',
-                              'unknown to unit_manager')
+        self.assertRaises(TraitError, setattr, obj, 'family_name',
+                          'unknown to unit_manager')
         self.failIf(obj is None)
         self.assertEqual(obj.family_name, 'time')
 
@@ -197,7 +197,7 @@ class TraitsTestCase(TestCase):
 
     def test_family_not_none(self):
         obj = FamilyNameStrictNotNone(family_name='length')
-        self.failUnlessRaises(TraitError, setattr, obj, 'family_name', None)
+        self.assertRaises(TraitError, setattr, obj, 'family_name', None)
 
         try:
             obj = FamilyNameStrictNotNone(family_name=None)
@@ -272,7 +272,7 @@ class TraitsTestCase(TestCase):
         # changing the family first.
         obj = FamilyNameWithUnitsLinkage()
 
-        self.failUnlessRaises(TraitError, setattr, obj, 'units', 'hours')
+        self.assertRaises(TraitError, setattr, obj, 'units', 'hours')
 
         obj.family_name = 'time'
         self.assertEqual(obj.family_name, 'time')

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -82,20 +82,20 @@ class TraitsTestCase(TestCase):
     def test_units_trait(self):
         obj = UnitsNonStrict(units='km')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'km')
+        self.assertEqual(obj.units.label, 'km')
 
         obj.units = 'm/sec**2'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'm/sec**2')
+        self.assertEqual(obj.units.label, 'm/sec**2')
 
         obj.units = 'invalid'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'invalid')
-        self.failUnlessEqual(obj.units.derivation, dimensionless.derivation)
+        self.assertEqual(obj.units.label, 'invalid')
+        self.assertEqual(obj.units.derivation, dimensionless.derivation)
 
         units = unit_parser.parse_unit('g/cc')
         self.failIf(units is None)
-        self.failUnlessEqual(units.label, 'g/cc')
+        self.assertEqual(units.label, 'g/cc')
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
@@ -117,22 +117,22 @@ class TraitsTestCase(TestCase):
     def test_strict_units_trait(self):
         obj = UnitsStrict(units='km')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'km')
+        self.assertEqual(obj.units.label, 'km')
 
         obj.units = 'm/sec**2'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'm/sec**2')
-        self.failUnlessEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
+        self.assertEqual(obj.units.label, 'm/sec**2')
+        self.assertEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
 
         self.failUnlessRaises(TraitError, setattr, obj, 'units', 'invalid')
 
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'm/sec**2')
-        self.failUnlessEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
+        self.assertEqual(obj.units.label, 'm/sec**2')
+        self.assertEqual(obj.units.derivation, (1, 0, -2, 0, 0, 0, 0))
 
         units = unit_parser.parse_unit('g/cc')
         self.failIf(units is None)
-        self.failUnlessEqual(units.label, 'g/cc')
+        self.assertEqual(units.label, 'g/cc')
         self.failIfEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
@@ -142,7 +142,7 @@ class TraitsTestCase(TestCase):
 
     def test_units_strict_with_family(self):
         obj = UnitsStrictWithFamily()
-        self.failUnlessEqual(obj.family_name, 'unknown')
+        self.assertEqual(obj.family_name, 'unknown')
 
         # anything is compatible with 'unknonw'
         obj.units = 'km/sec'
@@ -159,15 +159,15 @@ class TraitsTestCase(TestCase):
     def test_family_name_trait(self):
         obj = FamilyNameNonStrict(family_name='distance')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'distance')
+        self.assertEqual(obj.family_name, 'distance')
 
         obj.family_name = 'time'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'time')
+        self.assertEqual(obj.family_name, 'time')
 
         obj.family_name = 'unknown to unit_manager'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'unknown to unit_manager')
+        self.assertEqual(obj.family_name, 'unknown to unit_manager')
 
         obj = FamilyNameNonStrict()
         self.failIf(obj is None)
@@ -178,16 +178,16 @@ class TraitsTestCase(TestCase):
     def test_family_name_strict_trait(self):
         obj = FamilyNameStrict(family_name='distance')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'distance')
+        self.assertEqual(obj.family_name, 'distance')
 
         obj.family_name = 'time'
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'time')
+        self.assertEqual(obj.family_name, 'time')
 
         self.failUnlessRaises(TraitError, setattr, obj, 'family_name',
                               'unknown to unit_manager')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'time')
+        self.assertEqual(obj.family_name, 'time')
 
         obj = FamilyNameNonStrict()
         self.failIf(obj is None)
@@ -211,8 +211,8 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameWithUnitsLinkage()
 
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.family_name, 'length')
-        self.failUnlessEqual(obj.units.label, 'm')
+        self.assertEqual(obj.family_name, 'length')
+        self.assertEqual(obj.units.label, 'm')
 
         return
 
@@ -223,16 +223,16 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameWithUnitsLinkage()
 
         obj.family_name = 'distance'
-        self.failUnlessEqual(obj.family_name, 'distance')
-        self.failUnlessEqual(obj.units.label, 'm')
+        self.assertEqual(obj.family_name, 'distance')
+        self.assertEqual(obj.units.label, 'm')
 
         obj.units = 'ft'
-        self.failUnlessEqual(obj.family_name, 'distance')
-        self.failUnlessEqual(obj.units.label, 'ft')
+        self.assertEqual(obj.family_name, 'distance')
+        self.assertEqual(obj.units.label, 'ft')
 
         obj.family_name = 'length'
-        self.failUnlessEqual(obj.family_name, 'length')
-        self.failUnlessEqual(obj.units.label, 'ft')
+        self.assertEqual(obj.family_name, 'length')
+        self.assertEqual(obj.units.label, 'ft')
 
         return
 
@@ -243,8 +243,8 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameWithUnitsLinkage()
 
         obj.family_name = 'time'
-        self.failUnlessEqual(obj.family_name, 'time')
-        self.failUnlessEqual(obj.units.label, 'msec')
+        self.assertEqual(obj.family_name, 'time')
+        self.assertEqual(obj.units.label, 'msec')
 
         return
 
@@ -255,16 +255,16 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameWithUnitsLinkage()
 
         obj.units = 'ft'
-        self.failUnlessEqual(obj.family_name, 'length')
-        self.failUnlessEqual(obj.units.label, 'ft')
+        self.assertEqual(obj.family_name, 'length')
+        self.assertEqual(obj.units.label, 'ft')
 
         obj.units = 'in'
-        self.failUnlessEqual(obj.family_name, 'length')
-        self.failUnlessEqual(obj.units.label, 'in')
+        self.assertEqual(obj.family_name, 'length')
+        self.assertEqual(obj.units.label, 'in')
 
         obj.units = 'cm'
-        self.failUnlessEqual(obj.family_name, 'length')
-        self.failUnlessEqual(obj.units.label, 'cm')
+        self.assertEqual(obj.family_name, 'length')
+        self.assertEqual(obj.units.label, 'cm')
 
     def test_family_with_units_units_change_not_compatible(self):
 
@@ -275,12 +275,12 @@ class TraitsTestCase(TestCase):
         self.failUnlessRaises(TraitError, setattr, obj, 'units', 'hours')
 
         obj.family_name = 'time'
-        self.failUnlessEqual(obj.family_name, 'time')
-        self.failUnlessEqual(obj.units.label, 'msec')
+        self.assertEqual(obj.family_name, 'time')
+        self.assertEqual(obj.units.label, 'msec')
 
         obj.units = 'hour'
-        self.failUnlessEqual(obj.family_name, 'time')
-        self.failUnlessEqual(obj.units.label, 'hour')
+        self.assertEqual(obj.family_name, 'time')
+        self.assertEqual(obj.units.label, 'hour')
 
         return
 
@@ -294,19 +294,19 @@ class TraitsTestCase(TestCase):
 
         obj = UnitsNonStrict(units='km')
         self.failIf(obj is None)
-        self.failUnlessEqual(obj.units.label, 'km')
+        self.assertEqual(obj.units.label, 'km')
 
         obj.on_trait_change(self._units_changed)
 
         obj.units = 'ft'
-        self.failUnlessEqual(len(self.event_change_log), 1)
-        self.failUnlessEqual(self.event_change_log[0][0], 'units')
-        self.failUnlessEqual(obj.units.label, 'ft')
+        self.assertEqual(len(self.event_change_log), 1)
+        self.assertEqual(self.event_change_log[0][0], 'units')
+        self.assertEqual(obj.units.label, 'ft')
 
         obj.units = 'feet'
-        self.failUnlessEqual(len(self.event_change_log), 2)
-        self.failUnlessEqual(self.event_change_log[1][0], 'units')
-        self.failUnlessEqual(obj.units.label, 'feet')
+        self.assertEqual(len(self.event_change_log), 2)
+        self.assertEqual(self.event_change_log[1][0], 'units')
+        self.assertEqual(obj.units.label, 'feet')
 
     def ui_family_with_units(self):
         obj = FamilyNameWithUnitsLinkage()

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -96,7 +96,7 @@ class TraitsTestCase(TestCase):
         units = unit_parser.parse_unit('g/cc')
         self.assertFalse(units is None)
         self.assertEqual(units.label, 'g/cc')
-        self.failIfEqual(units.derivation, dimensionless.derivation)
+        self.assertNotEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
         self.assertTrue(obj.units is units)
@@ -133,7 +133,7 @@ class TraitsTestCase(TestCase):
         units = unit_parser.parse_unit('g/cc')
         self.assertFalse(units is None)
         self.assertEqual(units.label, 'g/cc')
-        self.failIfEqual(units.derivation, dimensionless.derivation)
+        self.assertNotEqual(units.derivation, dimensionless.derivation)
 
         obj.units = units
         self.assertTrue(obj.units is units)

--- a/scimath/units/tests/test_unit_array.py
+++ b/scimath/units/tests/test_unit_array.py
@@ -141,7 +141,7 @@ class UnitArrayTestCase(unittest.TestCase):
 
         # Test the values are correct
         desired_array = units.convert(ary, meters, feet)
-        self.assert_(numpy.all(desired_array == new_unit_ary))
+        self.assertTrue(numpy.all(desired_array == new_unit_ary))
 
         # Also, make sure the units are correctly assigned.
         self.assertEqual(new_unit_ary.units, feet)
@@ -347,7 +347,7 @@ class PassUnitsTestCase(unittest.TestCase):
     def test_sqrt_no_pass(self):
         a = UnitArray([1.0, 2.0, 3.0], units=meters / second)
         result = sqrt(a)
-        self.assert_(result.units is None)
+        self.assertTrue(result.units is None)
 
     def test_sqrt_pass(self):
         a = UnitArray([1.0, 2.0, 3], units=dimensionless)

--- a/scimath/units/tests/test_unit_manipulation.py
+++ b/scimath/units/tests/test_unit_manipulation.py
@@ -358,17 +358,17 @@ class StripUnitsTestCase(unittest.TestCase):
 
     def test_strip_units_multi_arg(self):
         outs = strip_units(self.unit_array, self.unit_scalar)
-        self.assertEquals(len(outs), 2)
+        self.assertEqual(len(outs), 2)
         for x in outs:
             self.assertFalse(isinstance(x, (UnitArray, UnitScalar)))
 
         outs = strip_units(self.plain_array, self.plain_scalar)
-        self.assertEquals(len(outs), 2)
+        self.assertEqual(len(outs), 2)
         for x in outs:
             self.assertFalse(isinstance(x, (UnitArray, UnitScalar)))
 
         outs = strip_units(self.unit_array, self.unit_scalar, self.plain_array,
                            self.plain_scalar)
-        self.assertEquals(len(outs), 4)
+        self.assertEqual(len(outs), 4)
         for x in outs:
             self.assertFalse(isinstance(x, (UnitArray, UnitScalar)))

--- a/scimath/units/tests/test_units.py
+++ b/scimath/units/tests/test_units.py
@@ -292,11 +292,11 @@ class test_units(unittest.TestCase):
     def test_family_compatibility(self):
         """ test are_compatible_families """
 
-        self.assert_(unit_manager.are_compatible_families('none', 'pvelocity'))
-        self.assert_(unit_manager.are_compatible_families('none', 'foo'))
-        self.assert_(unit_manager.are_compatible_families('foo', 'foo'))
-        self.assert_(not unit_manager.are_compatible_families('bar', 'foo'))
-        self.assert_(not unit_manager.are_compatible_families('bar', 'none'))
+        self.assertTrue(unit_manager.are_compatible_families('none', 'pvelocity'))
+        self.assertTrue(unit_manager.are_compatible_families('none', 'foo'))
+        self.assertTrue(unit_manager.are_compatible_families('foo', 'foo'))
+        self.assertTrue(not unit_manager.are_compatible_families('bar', 'foo'))
+        self.assertTrue(not unit_manager.are_compatible_families('bar', 'none'))
 
     def test_get_inverse(self):
         """ test get_inverse_family_name and get_inverse_name """
@@ -318,8 +318,8 @@ class test_units(unittest.TestCase):
         um2 = length.m
         uft = length.feet
 
-        self.assert_(um1 == um2)
-        self.assert_(not(um1 == uft))
+        self.assertTrue(um1 == um2)
+        self.assertTrue(not(um1 == uft))
 
         return
 
@@ -329,8 +329,8 @@ class test_units(unittest.TestCase):
         um2 = length.m
         uft = length.feet
 
-        self.assert_(not(um1 != um2))
-        self.assert_(um1 != uft)
+        self.assertTrue(not(um1 != um2))
+        self.assertTrue(um1 != uft)
 
         return
 
@@ -340,8 +340,8 @@ class test_units(unittest.TestCase):
         qm2 = Quantity(2, units='m', family_name='depth')
         qft = Quantity(1, units='feet', family_name='depth')
 
-        self.assert_(qm1.units == qm2.units)
-        self.assert_(not(qm1.units == qft.units))
+        self.assertTrue(qm1.units == qm2.units)
+        self.assertTrue(not(qm1.units == qft.units))
 
         return
 
@@ -351,8 +351,8 @@ class test_units(unittest.TestCase):
         qm2 = Quantity(2, units='m', family_name='depth')
         qft = Quantity(1, units='feet', family_name='depth')
 
-        self.assert_(not(qm1.units != qm2.units))
-        self.assert_(qm1.units != qft.units)
+        self.assertTrue(not(qm1.units != qm2.units))
+        self.assertTrue(qm1.units != qft.units)
 
         return
 


### PR DESCRIPTION
fixes #124 

This PR addresses the following `unittest`-related deprecations and replaces them with the corresponding methods

- `assert_` with `assertTrue`
- `assertEquals` with `assertEqual`
- `failUnlessEqual` with `assertEqual`
- `failUnlessRaises` with `assertRaises`
- `failIf` with `assertFalse`
- `failUnless` with `assertTrue`
- `failIfEqual` with `assertNotEqual`

Additionally, this PR takes the opportinity to rewrite two tests that explicitly call `unittest.TestCase.fail` when an expected error isn't raised to simply use `assertRaises` instead.