### PR TITLE
Use "enthought_sphinx_theme" and "sphinx" from edm

### DIFF
--- a/ci-doc-requirements.txt
+++ b/ci-doc-requirements.txt
@@ -1,2 +1,0 @@
-sphinx
-git+http://github.com/enthought/enthought-sphinx-theme

--- a/etstool.py
+++ b/etstool.py
@@ -92,6 +92,8 @@ dependencies = {
     "traits",
     "nose",
     "coverage",
+    "sphinx",
+    "enthought_sphinx_theme",
 }
 
 


### PR DESCRIPTION
Previously, we were installing `sphinx` from PyPI and `enthought_sphinx_theme` from git/github source. This PR updates the ets utility to install both via EDM.