### PR TITLE
Remove broken "print" statements

### DIFF
--- a/scimath/units/smart_unit.py
+++ b/scimath/units/smart_unit.py
@@ -100,19 +100,15 @@ class SmartUnit(OffsetUnit):
         """ If `units.convert()` fails to run then the two units
         systems specified are probably not consistent.
         """
-        # print 'Comparing the dimensionality of %s and %s' % (self, new_unit)
-        # print repr(self), repr(new_unit)
         # parse errors generate dimensionless units so if they both end up
         # being dimensionless but invalid convert() will not throw an exception
         if not self.is_valid() or not new_unit.is_valid():
-            # print 'Invalid units ', self.is_valid(), new_unit.is_valid()
             return False
 
         try:
             convert(1.0, self, new_unit)
             ok = True
         except Exception as msg:
-            # print 'Failed at convert stage ', msg
             ok = False
 
         return ok

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -285,8 +285,6 @@ class TraitsTestCase(TestCase):
         return
 
     def _units_changed(self, obj, name, old, new):
-        # print "_units_changed name: '%s' old: '%s' new: '%s'" \
-        #    % ( name, old, new )
         self.event_change_log.append((name, old, new))
 
     def test_units_events(self):

--- a/scimath/units/tests/test_unit_manipulation.py
+++ b/scimath/units/tests/test_unit_manipulation.py
@@ -236,7 +236,6 @@ class SetUnitsTestCase(unittest.TestCase):
         # should not have.
         #
         #self.assertEqual(x, xx)
-        # print x, x.units
         self.assertEqual(xx.units, feet)
 
     def test_set_unit_overwrite_unit_array(self):

--- a/scimath/units/unit_converter.py
+++ b/scimath/units/unit_converter.py
@@ -119,7 +119,6 @@ def convert_log_index(log_index, unit_system=None,
         new_log_index = log_index.clone()
         new_log_index.family_name = family_name  # TODO: not sure if I need this
     else:
-        # print "To_units", to_unit, log_index.units, family_name, unit_system
         data = units_convert(log_index.data, log_index.units, to_unit)
         new_log_index = log_index.clone(data=data)
         new_log_index.family_name = family_name

--- a/scimath/units/unit_db.py
+++ b/scimath/units/unit_db.py
@@ -77,7 +77,6 @@ class UnitDB(object):
                         print(
                             'Warning: duplicate key: %s in %s' %
                             (member_name, filename))
-                    # print '    adding %s to member_names...' % member_name
                     self.member_names[member_name] = family_name
 
                 # set up the preferred log name for the family to be the


### PR DESCRIPTION
This PR removes broken `print` statements, which were potentially used for debugging. Note that I refer to `print` statements, not `print()` function calls. There are still a few, what feel like meaningful, calls to `print()` in the codebase.