### PR TITLE
Remove unnecessary "return" statements

### DIFF
--- a/scimath/units/meta_quantity.py
+++ b/scimath/units/meta_quantity.py
@@ -48,8 +48,6 @@ class MetaQuantity(HasStrictTraits):
             self.family_name = family_name
             self.units = units
 
-        return
-
     ###########################################################################
     # HasTraits interface
     ###########################################################################
@@ -72,4 +70,3 @@ class MetaQuantity(HasStrictTraits):
         the defaults for that name.
         """
         self.family_name = unit_manager.get_family_name(self.name)
-        return

--- a/scimath/units/quantity.py
+++ b/scimath/units/quantity.py
@@ -173,8 +173,6 @@ class Quantity(HasPrivateTraits):
         #self.__dict__['data'] = self._convert(data, units)
         #self.__dict__['units'] = units
 
-        return
-
     def __repr__(self):
         """ Return the string representation of this quantity. """
 
@@ -314,8 +312,6 @@ class Quantity(HasPrivateTraits):
 
         # Recursively continue propagating.
         predecessor.propagate_data_changes()
-
-        return
 
     def get_original(self):
         """ Returns the original quantity in the conversion stack. """

--- a/scimath/units/style_manager.py
+++ b/scimath/units/style_manager.py
@@ -54,8 +54,6 @@ class StyleManager(HasPrivateTraits):
         udb.get_family_ranges_from_file()
         self.ranges = udb.unit_ranges
 
-        return
-
     ###########################################################################
     # 'StyleManager' interface.
     ###########################################################################

--- a/scimath/units/tests/test_meta_quantity.py
+++ b/scimath/units/tests/test_meta_quantity.py
@@ -22,7 +22,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(mq.name, 'vp')
         self.failUnlessEqual(mq.units.label, 'km/s')
         self.failUnlessEqual(mq.family_name, 'pvelocity')
-        return
 
     def test_metaquantity_compatible_family_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
@@ -32,7 +31,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(mq.name, 'vs')
         self.failUnlessEqual(mq.units.label, 'km/s')
         self.failUnlessEqual(mq.family_name, 'svelocity')
-        return
 
     def test_metaquantity_compatible_units_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
@@ -41,7 +39,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(mq.name, 'vp')
         self.failUnlessEqual(mq.units.label, 'ft/s')
         self.failUnlessEqual(mq.family_name, 'pvelocity')
-        return
 
     def test_metaquantity_incompatible_units_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
@@ -51,7 +48,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(mq.name, 'vp')
         self.failUnlessEqual(mq.units.label, 'km/s')
         self.failUnlessEqual(mq.family_name, 'pvelocity')
-        return
 
     def test_metaquantity_incompatible_family_change(self):
         mq = MetaQuantity(name='vp', units='km/s', family_name='pvelocity')
@@ -61,11 +57,9 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(mq.name, 'vp')
         self.failUnlessEqual(mq.units.label, 'msec')
         self.failUnlessEqual(mq.family_name, 'time')
-        return
 
     def ui_simple(self):
         mq = MetaQuantity()
         mq.configure_traits(kind='modal')
         print('\n')
         mq.print_traits()
-        return

--- a/scimath/units/tests/test_traits.py
+++ b/scimath/units/tests/test_traits.py
@@ -74,8 +74,6 @@ class FamilyNameWithUnitsLinkage(HasTraits):
             self.family_name = family_name
             self.units = units
 
-        return
-
 
 class TraitsTestCase(TestCase):
 
@@ -101,8 +99,6 @@ class TraitsTestCase(TestCase):
         obj.units = units
         self.failUnless(obj.units is units)
 
-        return
-
     def test_units_not_none(self):
         obj = UnitsStrictNotNone(units='km')
         self.failUnlessRaises(TraitError, setattr, obj, 'units', None)
@@ -112,7 +108,6 @@ class TraitsTestCase(TestCase):
             self.fail('Constructor did not raise TraitError with units=None')
         except TraitError:
             pass
-        return
 
     def test_strict_units_trait(self):
         obj = UnitsStrict(units='km')
@@ -138,8 +133,6 @@ class TraitsTestCase(TestCase):
         obj.units = units
         self.failUnless(obj.units is units)
 
-        return
-
     def test_units_strict_with_family(self):
         obj = UnitsStrictWithFamily()
         self.failUnlessEqual(obj.family_name, 'unknown')
@@ -153,8 +146,6 @@ class TraitsTestCase(TestCase):
         obj.units = 'km'
 
         self.failUnlessRaises(TraitError, setattr, obj, 'units', 'g/cc')
-
-        return
 
     def test_family_name_trait(self):
         obj = FamilyNameNonStrict(family_name='distance')
@@ -172,8 +163,6 @@ class TraitsTestCase(TestCase):
         obj = FamilyNameNonStrict()
         self.failIf(obj is None)
         self.failUnless(obj.family_name is None)
-
-        return
 
     def test_family_name_strict_trait(self):
         obj = FamilyNameStrict(family_name='distance')
@@ -193,8 +182,6 @@ class TraitsTestCase(TestCase):
         self.failIf(obj is None)
         self.failUnless(obj.family_name is None)
 
-        return
-
     def test_family_not_none(self):
         obj = FamilyNameStrictNotNone(family_name='length')
         self.failUnlessRaises(TraitError, setattr, obj, 'family_name', None)
@@ -205,7 +192,6 @@ class TraitsTestCase(TestCase):
                 'Constructor did not raise TraitError with family_name=None')
         except TraitError:
             pass
-        return
 
     def test_family_with_units_defaults(self):
         obj = FamilyNameWithUnitsLinkage()
@@ -213,8 +199,6 @@ class TraitsTestCase(TestCase):
         self.failIf(obj is None)
         self.failUnlessEqual(obj.family_name, 'length')
         self.failUnlessEqual(obj.units.label, 'm')
-
-        return
 
     def test_family_with_units_family_change_with_compatible_units(self):
 
@@ -234,8 +218,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(obj.family_name, 'length')
         self.failUnlessEqual(obj.units.label, 'ft')
 
-        return
-
     def test_family_with_units_family_change_causes_units_change(self):
 
         # family change with incompatible units should reset units to default
@@ -245,8 +227,6 @@ class TraitsTestCase(TestCase):
         obj.family_name = 'time'
         self.failUnlessEqual(obj.family_name, 'time')
         self.failUnlessEqual(obj.units.label, 'msec')
-
-        return
 
     def test_family_with_units_units_change_compatible(self):
 
@@ -282,8 +262,6 @@ class TraitsTestCase(TestCase):
         self.failUnlessEqual(obj.family_name, 'time')
         self.failUnlessEqual(obj.units.label, 'hour')
 
-        return
-
     def _units_changed(self, obj, name, old, new):
         # print "_units_changed name: '%s' old: '%s' new: '%s'" \
         #    % ( name, old, new )
@@ -313,5 +291,3 @@ class TraitsTestCase(TestCase):
         obj.configure_traits(kind='modal')
         print('\n')
         obj.print_traits()
-
-        return

--- a/scimath/units/tests/test_units.py
+++ b/scimath/units/tests/test_units.py
@@ -71,17 +71,14 @@ class test_units(unittest.TestCase):
     def test_with_si(self):
         f = self._compute_force(mass, acc)
         self.assertEqual(f, mass * acc)
-        return
 
     def test_with_ton(self):
         f = self._compute_force(mass / 1000, acc, mass_units=metric_ton)
         self.assertEqual(f, mass * acc)
-        return
 
     def test_with_imp(self):
         f = self._compute_force(mass, acc_imp, acc_units=fs2)
         self.assertAlmostEqual(f, mass * acc, 4)
-        return
 
     def test_temperature(self):
         k = 200
@@ -97,22 +94,18 @@ class test_units(unittest.TestCase):
         self.assertAlmostEqual(t1, -40.0, 6)
         t2 = units.convert(0.0, temperature.celsius, temperature.fahrenheit)
         self.assertAlmostEqual(t2, 32.0, 6)
-        return
 
     def test_area(self):
         self.assertEqual(1 * area.square_mile / (640 * area.acre), 1.0)
-        return
 
     def test_density(self):
         d1 = units.convert(1, density.lb_per_gal,
                            density.grams_per_cubic_centimeter)
         self.assertAlmostEqual(d1, 0.1198284429, 6)
-        return
 
     def test_frequency(self):
         f1 = units.convert(1, frequency.hertz, frequency.khz)
         self.assertAlmostEqual(f1, 0.001, 6)
-        return
 
     def test_speed(self):
         s1 = units.convert(55, speed.miles_per_hour, speed.meters_per_second)
@@ -179,8 +172,6 @@ class test_units(unittest.TestCase):
         self.assertEqual(q2, q3._converted_from,
                          "Conversion failed to track conversion parent.")
 
-        return
-
     def test_propagation_base(self):
         """ Tests that propagation works for an original quantity. """
 
@@ -189,8 +180,6 @@ class test_units(unittest.TestCase):
 
         self.assertEqual(10, q1.data,
                          "Propagation modified the base data.")
-
-        return
 
     def test_propagation(self):
         """ Tests data propagation for a single converted quantity. """
@@ -211,8 +200,6 @@ class test_units(unittest.TestCase):
         self.assertAlmostEqual(30., q1.data, 1,
                                "Propagation test expected data 30, got %s" % str(q1.data))
 
-        return
-
     def test_get_original(self):
 
         q1 = Quantity(10, units='m', family_name='depth')
@@ -225,8 +212,6 @@ class test_units(unittest.TestCase):
                          "First child get_original failed to return original.")
         self.assertEqual(q1, q3.get_original(),
                          "Second child get_original failed to return original.")
-
-        return
 
     def test_unit_parser_dimensionless(self):
         for label in ['', 'None', 'none', 'unknown', 'unitless']:
@@ -321,8 +306,6 @@ class test_units(unittest.TestCase):
         self.assert_(um1 == um2)
         self.assert_(not(um1 == uft))
 
-        return
-
     def test_unit_notequal(self):
         """ test unit class __ne__ method"""
         um1 = length.m
@@ -331,8 +314,6 @@ class test_units(unittest.TestCase):
 
         self.assert_(not(um1 != um2))
         self.assert_(um1 != uft)
-
-        return
 
     def test_smart_unit_equal(self):
         """ test smart unit class __eq__ method"""
@@ -343,8 +324,6 @@ class test_units(unittest.TestCase):
         self.assert_(qm1.units == qm2.units)
         self.assert_(not(qm1.units == qft.units))
 
-        return
-
     def test_smart_unit_notequal(self):
         """ test smart unit class __ne__ method"""
         qm1 = Quantity(1, units='m', family_name='depth')
@@ -353,8 +332,6 @@ class test_units(unittest.TestCase):
 
         self.assert_(not(qm1.units != qm2.units))
         self.assert_(qm1.units != qft.units)
-
-        return
 
     def test_get_family_name(self):
         """ test get_family_name with standard and ?/* type matching """

--- a/scimath/units/ui/quantity_view.py
+++ b/scimath/units/ui/quantity_view.py
@@ -51,7 +51,6 @@ class QuantityViewHandler(Handler):
         if not is_ok:
             qty = info.ui.context['object']
             qty.copy_traits(self.original)
-        return
 
     def setattr(self, info, object, name, value):
         """ Handles setting a specified object trait's value.
@@ -77,8 +76,6 @@ class QuantityViewHandler(Handler):
 
         super(QuantityViewHandler, self).setattr(info, object, name, value)
 
-        return
-
     def object_family_name_changed(self, info):
         """ Family name has changed, force the units to re-validate. """
         if info.initialized:
@@ -92,5 +89,3 @@ class QuantityViewHandler(Handler):
                 if editor.name == 'units':
                     editor.update_object(None)
                     break
-
-        return

--- a/scimath/units/unit.py
+++ b/scimath/units/unit.py
@@ -32,7 +32,6 @@ class unit(object):
         self.derivation = derivation
         self.label = None
         self.offset = offset
-        return
 
     def __eq__(self, other):
         """ Are these the same types of units (e.g., feet) """
@@ -225,7 +224,6 @@ class InvalidConversion(Exception):
 
     def __init__(self, operand):
         self._op = operand
-        return
 
     def __str__(self):
         str = "dimensional quantities ('%s') " % self._op._strDerivation()
@@ -239,7 +237,6 @@ class InvalidOperation(Exception):
         self._op = op
         self._op1 = operand1
         self._op2 = operand2
-        return
 
     def __str__(self):
         str = "Invalid expression: %s %s %s" % (self._op1, self._op, self._op2)
@@ -252,7 +249,6 @@ class IncompatibleUnits(Exception):
         self._op = op
         self._op1 = operand1
         self._op2 = operand2
-        return
 
     def __str__(self):
         str = "Cannot %s quanitites with units of '%s' and '%s'" % \

--- a/scimath/units/unit_db.py
+++ b/scimath/units/unit_db.py
@@ -90,7 +90,6 @@ class UnitDB(object):
 
         fh.close()
         logger.debug('Loading default unit info...Done')
-        return
 
     def get_family_format_from_file(self, filename=None):
         """Retrieves a list of formatting parameters from a file.
@@ -142,7 +141,6 @@ class UnitDB(object):
 
         fh.close()
         logger.debug('Loading default unit info...Done')
-        return
 
     def get_unit_families_from_file(self, filename=None):
         """Retrieves a list of family names and member lists from a file.
@@ -185,7 +183,6 @@ class UnitDB(object):
                         converters.append(cvt_str)
         fh.close()
         logger.debug('Loading default unit info...Done')
-        return
 
     def get_family_ranges_from_file(self, filename=None):
         """Retrieves a list of left/right range parameters from a file.
@@ -245,7 +242,6 @@ class UnitDB(object):
 
         fh.close()
         logger.debug('Loading default unit info...Done')
-        return
 
     #  Return a list of the available unit systems eg 'kgs','metric','imperial'
     def get_unit_systems(self):

--- a/scimath/units/unit_manager.py
+++ b/scimath/units/unit_manager.py
@@ -75,8 +75,6 @@ class UnitCache(HasTraits):
             self.cache.popitem()
             self.cache[name] = value
 
-        return
-
     def reset(self):
         self.cache = {}
 
@@ -142,8 +140,6 @@ class UnitManager(HasPrivateTraits):
 
         self.default_system = self.unit_systems[0]
 
-        return
-
     ###########################################################################
     # 'UnitManager' interface.
     ###########################################################################
@@ -178,8 +174,6 @@ class UnitManager(HasPrivateTraits):
         logger.info(
             "Unit manager - default unit system set to: %s" %
             self.default_system)
-
-        return
 
     def lookup_system(self, name):
         """ Returns the unit system with the specified name or raises
@@ -245,7 +239,6 @@ class UnitManager(HasPrivateTraits):
             self._wildcards.append(member_name)
         # clear out the cache
         self._family_cache.reset()
-        return
 
     def add_family(self, family_name, description, inverse):
         """ Maintains dict of families w/ description & inverse values """
@@ -497,7 +490,6 @@ class IncompatibleUnitFamilies(Exception):
     def __init__(self, fromFamily, toFamily):
         self._toFamily = toFamily
         self._fromFamily = fromFamily
-        return
 
     def __str__(self):
         str = "Cannot convert across unit families: '%s' and '%s'" % \

--- a/scimath/units/unit_parser.py
+++ b/scimath/units/unit_parser.py
@@ -151,8 +151,6 @@ class UnitParser:
         # This is used to clean up labels like ohm.m in remove_dots()
         self.regex = re.compile(r'([A-Za-z])\.([A-Za-z])')
 
-        return
-
     def parse_unit(self, label, suppress_warnings=True, suppress_unknown=True):
         """ Parses a string description of a unit e.g., 'g/cc'.
         if suppress_unknown is True and the label cannot be parsed, the returned
@@ -296,7 +294,6 @@ class UnableToParseUnits(Exception):
 
     def __init__(self, label):
         self.label = label
-        return
 
     def __str__(self):
         str = "Label '%s' is not a parseable unit string." % \

--- a/scimath/units/unit_system.py
+++ b/scimath/units/unit_system.py
@@ -67,8 +67,6 @@ class UnitSystem(HasTraits):
                     families[1],
                     families[2])
 
-        return
-
     def units(self, name):
         """ Method to return a unit for a given family or member name """
 

--- a/scimath/units/wx/quantity_editor.py
+++ b/scimath/units/wx/quantity_editor.py
@@ -115,8 +115,6 @@ class SimpleQuantityEditor(QuantityEditor):
 
         self.control = panel
 
-        return
-
     def update_editor(self):
         """ Updates the editor when the object trait changes external to the
             editor.
@@ -125,8 +123,6 @@ class SimpleQuantityEditor(QuantityEditor):
         string_value = self.string_value(self._to_display_units(self.value))
         self.text_control.SetValue(string_value)
         self._updating_editor = False
-
-        return
 
     def update_object(self, event, assign=True):
         """ Handles the user changing the contents of the edit control.
@@ -179,8 +175,6 @@ class ReadOnlyQuantityEditor(Editor):
         control.SetBackgroundColour(ReadonlyColor)
         self.control = control
 
-        return
-
     def update_editor(self):
         """ Updates the editor when the object trait changes external to the
             editor.
@@ -190,5 +184,3 @@ class ReadOnlyQuantityEditor(Editor):
         string_value = '%s %s' % (self.to_default_units(self.value),
                                   self._get_family_name(self.value))
         self.control.SetValue(string_value)
-
-        return


### PR DESCRIPTION
This PR tries to remove unnecessary `return` statements from the codebase. Note that we checked each instance of `return \n` and removed ones which were redundant. Note that it is possible there are some more `return` statements which are unnecessary.