### PR TITLE
Remove unnecessary calls to "unittest.TestCase" "setUp" and "tearDown"

### DIFF
--- a/scimath/units/tests/test_function_signature.py
+++ b/scimath/units/tests/test_function_signature.py
@@ -18,16 +18,6 @@ class FunctionArgumentsDocTestCase(doctest_for_module(function_signature)):
 class FunctionArgumentsTestCase(unittest.TestCase):
 
     ##########################################################################
-    # TestCase interface.
-    ##########################################################################
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-
-    ##########################################################################
     # FunctionArgumentsTestCase interface.
     ##########################################################################
 
@@ -95,16 +85,6 @@ class FunctionArgumentsTestCase(unittest.TestCase):
 class DefSignatureTestCase(unittest.TestCase):
 
     ##########################################################################
-    # TestCase interface.
-    ##########################################################################
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-
-    ##########################################################################
     # FunctionArgumentsTestCase interface.
     ##########################################################################
 
@@ -126,16 +106,6 @@ class DefSignatureTestCase(unittest.TestCase):
 
 
 class CallSignatureTestCase(unittest.TestCase):
-
-    ##########################################################################
-    # TestCase interface.
-    ##########################################################################
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
 
     ##########################################################################
     # FunctionArgumentsTestCase interface.

--- a/scimath/units/tests/test_has_units.py
+++ b/scimath/units/tests/test_has_units.py
@@ -27,12 +27,6 @@ class HasUnitsTestCase(unittest.TestCase):
     # TestCase interface.
     ##########################################################################
 
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-
     def failUnlessEqual(self, first, second, msg=None):
         """Fail if the two objects are unequal as determined by the '=='
            operator.
@@ -337,7 +331,6 @@ class HasUnitsDecoratorTestCase(unittest.TestCase):
         self.meter_scalar = UnitScalar(1., units=meters)
         self.second_scalar = UnitScalar(3., units=second)
         self.feet_scalar = UnitScalar(4., units=feet)
-        unittest.TestCase.setUp(self)
 
     def test_decorator_plays_nice(self):
         self.assertEquals(foo_with_units.__module__, foo.__module__)

--- a/scimath/units/tests/test_unit_array.py
+++ b/scimath/units/tests/test_unit_array.py
@@ -24,16 +24,6 @@ from scimath.units.api import UnitArray, UnitScalar
 class UnitArrayTestCase(unittest.TestCase):
 
     ##########################################################################
-    # unittest.TestCase interface
-    ##########################################################################
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-
-    ##########################################################################
     # Test construction from arrays
     ##########################################################################
 

--- a/scimath/units/tests/test_unit_manipulation.py
+++ b/scimath/units/tests/test_unit_manipulation.py
@@ -157,16 +157,6 @@ class ConvertUnitsTestCase(unittest.TestCase):
 class SetUnitsTestCase(unittest.TestCase):
 
     ##########################################################################
-    # TestCase interface.
-    ##########################################################################
-
-    def setUp(self):
-        unittest.TestCase.setUp(self)
-
-    def tearDown(self):
-        unittest.TestCase.tearDown(self)
-
-    ##########################################################################
     # SetUnitsTestCase interface.
     ##########################################################################
 
@@ -287,7 +277,6 @@ class HaveSomeUnitsTestCase(unittest.TestCase):
         self.unit_scalar = UnitScalar(1, units=meters)
         self.plain_array = array([1, 2, 3])
         self.plain_scalar = 1
-        unittest.TestCase.setUp(self)
 
     def test_finds_one(self):
         self.assertTrue(have_some_units(self.unit_array))
@@ -340,7 +329,6 @@ class StripUnitsTestCase(unittest.TestCase):
         self.unit_scalar = UnitScalar(1, units=meters)
         self.plain_array = array([1, 2, 3])
         self.plain_scalar = 1
-        unittest.TestCase.setUp(self)
 
     def test_strip_units_one_arg(self):
         self.assertFalse(isinstance(strip_units(self.unit_array),


### PR DESCRIPTION
This PR removes unnecessary calls to `unittest.TestCase` `setUp` and `tearDown` methods.