### PR TITLE
Stop trying to include "scimath.units.plugin.images" in the manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,3 @@ include LICENSE.txt
 include README.rst
 include pyproject.toml
 recursive-include scimath/units/data *.txt
-recursive-include scimath/units/plugin/images *.txt *.png


### PR DESCRIPTION
This PR stops including `scimath.units.plugin.images` in the manifest file. We missed this in #109 .