### PR TITLE
Reconcile differences in prerequisites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,5 +15,6 @@ calculations, beyond the capabilities offered by SciPy.
 Prerequisites
 -------------
 
-* `NumPy <http://pypi.python.org/pypi/numpy>`_
-* `SciPy <http://pypi.python.org/pypi/scipy>`_
+* `Traits <https://pypi.python.org/pypi/traits>`_
+* `NumPy <https://pypi.python.org/pypi/numpy>`_
+* `SciPy <https://pypi.python.org/pypi/scipy>`_

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ def write_version_py(filename=DEFAULT_VERSION_FILE,
 
 DEPENDENCIES = [
     'traits',
+    'numpy',
     'scipy',
 ]
 


### PR DESCRIPTION
fixes #77 

Explicitly list `numpy` as a dependency in the setup script and list `traits` as a prerequisite in the README.