### PR TITLE
Remove unnecessary/outdated TODO file

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,0 @@
-* Remove the explicit usage of wx.  GUI backends should be swappable.
-
-* Remove the imports of the cp library.
-


### PR DESCRIPTION
This PR removes the unnecessary/outdated TODO file from the git repository. This might have been used for project management before we moved to GitHub. This file is no longer necessary/relevant.