### PR TITLE
Stop reporting codecov on PRs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,3 @@ install:
   - edm run -- python etstool.py install --runtime=%runtime%
 test_script:
   - edm run -- python etstool.py test --runtime=%runtime%
-on_success:
-  - edm run -- coverage combine
-  - edm run -- pip install codecov
-  - edm run -- codecov


### PR DESCRIPTION
Code coverage reporting is simply adding noise to the PRs and most of the developers have developed selective blindless towards the reports at the moment.

This PR simply stops reporting code coverage on PRs.