### PR TITLE
Add alternate names with `µ` for micro instead of `u`

### DIFF
--- a/scimath/units/electromagnetism.py
+++ b/scimath/units/electromagnetism.py
@@ -57,8 +57,8 @@ ohms_per_meter = ohmm
 ###############################################################################
 
 micro_farad = micro * farad
-micro_farad.label = 'uf'
-mf = micro_farad
+micro_farad.label = 'µf'
+µf = uf = micro_farad
 
 pico_farad = pico * farad
 pico_farad.label = 'pf'

--- a/scimath/units/geo_units.py
+++ b/scimath/units/geo_units.py
@@ -93,5 +93,5 @@ gapi = copy(dimensionless)
 ###############################################################################
 # psonic
 ###############################################################################
-us_per_ft = microsecond / foot
-us_per_ft.label = 'us/ft'
+µs_per_ft = us_per_ft = microsecond / foot
+µs_per_ft.label = 'µs/ft'

--- a/scimath/units/time.py
+++ b/scimath/units/time.py
@@ -59,7 +59,7 @@ year.label = "year"
 s = sec = second
 ps = picosecond
 ns = nanosecond
-us = usec = microsecond
+µs = µsec = us = usec = microsecond
 ms = msec = millisecond
 
 # plural aliases


### PR DESCRIPTION
This also changes one label that was using `u` for "micro".

This keeps the old names around, so no code should break.

Fixes #135.