### PR TITLE
Add a RtD config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+python:
+  version: 3.8
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,10 @@ DEPENDENCIES = [
     'scipy',
 ]
 
+EXTRAS_REQUIRE = {
+    "docs": ["enthought-sphinx-theme", "sphinx"],
+}
+
 
 if __name__ == "__main__":
     __version__ = write_version_py()
@@ -163,6 +167,7 @@ if __name__ == "__main__":
         ext_modules=extensions,
         packages=find_packages(exclude=['docs', 'examples']),
         install_requires = DEPENDENCIES,
+        extras_require = EXTRAS_REQUIRE,
         license = "BSD",
         package_data = {'': ['images/*', 'data/*', 'scimath/units/data/*']},
         platforms = ["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],


### PR DESCRIPTION
This PR adds a basic configuration file for Read the Docs. These changes are based on enthought/traits#1478. This is one more step towards enthought/ets#69.

This PR also add a docs extras_require when installing traitsui to make it easy to build the sphinx docs.