### PR TITLE
`time.clock` Deprecation Fixed

### DIFF
--- a/scimath/interpolate/interpolate.py
+++ b/scimath/interpolate/interpolate.py
@@ -140,9 +140,9 @@ def main():
     x = arange(N)
     y = arange(N)
     new_x = arange(N) + 0.5
-    t1 = time.clock()
+    t1 = time.perf_counter()
     new_y = linear(x, y, new_x)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     print('1d interp (sec):', t2 - t1)
     print(new_y[:5])
 
@@ -151,9 +151,9 @@ def main():
     y = arange(N)
 
     new_x = arange(N / 2) * 2
-    t1 = time.clock()
+    t1 = time.perf_counter()
     new_y = block_average_above(x, y, new_x)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     print('1d block_average_above (sec):', t2 - t1)
     print(new_y[:5])
 
@@ -161,9 +161,9 @@ def main():
     x = arange(N)
     y = ones((100, N)) * arange(N)
     new_x = arange(N) + 0.5
-    t1 = time.clock()
+    t1 = time.perf_counter()
     new_y = linear(x, y, new_x)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     print('fast interpolate (sec):', t2 - t1)
     print(new_y[:5, :5])
 
@@ -172,10 +172,10 @@ def main():
     x = arange(N)
     y = ones((100, N)) * arange(N)
     new_x = arange(N)
-    t1 = time.clock()
+    t1 = time.perf_counter()
     interp = scipy.interpolate.interp1d(x, y)
     new_y = interp(new_x)
-    t2 = time.clock()
+    t2 = time.perf_counter()
     print('scipy interp1d (sec):', t2 - t1)
     print(new_y[:5, :5])
 

--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -29,9 +29,9 @@ class Test(unittest.TestCase):
     def test_linear(self):
         y = arange(self.N)
         new_x = arange(self.N) + 0.5
-        t1 = time.clock()
+        t1 = time.process_time()
         new_y = linear(self.x, y, new_x)
-        t2 = time.clock()
+        t2 = time.process_time()
 
         print('1d interp (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
@@ -39,9 +39,9 @@ class Test(unittest.TestCase):
     def test_block_average_above(self):
         y = arange(self.N)
         new_x = arange(self.N / 2) * 2
-        t1 = time.clock()
+        t1 = time.process_time()
         new_y = block_average_above(self.x, y, new_x)
-        t2 = time.clock()
+        t2 = time.process_time()
 
         print('1d block_average_above (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
@@ -49,9 +49,9 @@ class Test(unittest.TestCase):
     def test_linear2(self):
         y = ones((100, self.N)) * arange(self.N)
         new_x = arange(self.N) + 0.5
-        t1 = time.clock()
+        t1 = time.process_time()
         new_y = linear(self.x, y, new_x)
-        t2 = time.clock()
+        t2 = time.process_time()
 
         print('fast interpolate (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],
@@ -64,10 +64,10 @@ class Test(unittest.TestCase):
     def test_interp1d(self):
         y = ones((100, self.N)) * arange(self.N)
         new_x = arange(self.N)
-        t1 = time.clock()
+        t1 = time.process_time()
         interp = scipy.interpolate.interp1d(self.x, y)
         new_y = interp(new_x)
-        t2 = time.clock()
+        t2 = time.process_time()
 
         print('scipy interp1d (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],

--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -29,9 +29,9 @@ class Test(unittest.TestCase):
     def test_linear(self):
         y = arange(self.N)
         new_x = arange(self.N) + 0.5
-        t1 = time.process_time()
+        t1 = time.perf_counter()
         new_y = linear(self.x, y, new_x)
-        t2 = time.process_time()
+        t2 = time.perf_counter()
 
         print('1d interp (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
@@ -39,9 +39,9 @@ class Test(unittest.TestCase):
     def test_block_average_above(self):
         y = arange(self.N)
         new_x = arange(self.N / 2) * 2
-        t1 = time.process_time()
+        t1 = time.perf_counter()
         new_y = block_average_above(self.x, y, new_x)
-        t2 = time.process_time()
+        t2 = time.perf_counter()
 
         print('1d block_average_above (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
@@ -49,9 +49,9 @@ class Test(unittest.TestCase):
     def test_linear2(self):
         y = ones((100, self.N)) * arange(self.N)
         new_x = arange(self.N) + 0.5
-        t1 = time.process_time()
+        t1 = time.perf_counter()
         new_y = linear(self.x, y, new_x)
-        t2 = time.process_time()
+        t2 = time.perf_counter()
 
         print('fast interpolate (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],
@@ -64,10 +64,10 @@ class Test(unittest.TestCase):
     def test_interp1d(self):
         y = ones((100, self.N)) * arange(self.N)
         new_x = arange(self.N)
-        t1 = time.process_time()
+        t1 = time.perf_counter()
         interp = scipy.interpolate.interp1d(self.x, y)
         new_y = interp(new_x)
-        t2 = time.process_time()
+        t2 = time.perf_counter()
 
         print('scipy interp1d (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],

--- a/scimath/interpolate/tests/test_basic.py
+++ b/scimath/interpolate/tests/test_basic.py
@@ -22,37 +22,37 @@ class Test(unittest.TestCase):
     def assertAllclose(self, x, y):
         self.assertTrue(allclose(x, y))
 
+    def setUp(self):
+        self.N = 3000
+        self.x = arange(self.N)
+
     def test_linear(self):
-        N = 3000
-        x = arange(N)
-        y = arange(N)
-        new_x = arange(N) + 0.5
+        y = arange(self.N)
+        new_x = arange(self.N) + 0.5
         t1 = time.clock()
-        new_y = linear(x, y, new_x)
+        new_y = linear(self.x, y, new_x)
         t2 = time.clock()
+
         print('1d interp (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.5, 1.5, 2.5, 3.5, 4.5])
 
     def test_block_average_above(self):
-        N = 3000
-        x = arange(N)
-        y = arange(N)
-
-        new_x = arange(N / 2) * 2
+        y = arange(self.N)
+        new_x = arange(self.N / 2) * 2
         t1 = time.clock()
-        new_y = block_average_above(x, y, new_x)
+        new_y = block_average_above(self.x, y, new_x)
         t2 = time.clock()
+
         print('1d block_average_above (sec):', t2 - t1)
         self.assertAllclose(new_y[:5], [0.0, 0.5, 2.5, 4.5, 6.5])
 
     def test_linear2(self):
-        N = 3000
-        x = arange(N)
-        y = ones((100, N)) * arange(N)
-        new_x = arange(N) + 0.5
+        y = ones((100, self.N)) * arange(self.N)
+        new_x = arange(self.N) + 0.5
         t1 = time.clock()
-        new_y = linear(x, y, new_x)
+        new_y = linear(self.x, y, new_x)
         t2 = time.clock()
+
         print('fast interpolate (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],
                             [[0.5, 1.5, 2.5, 3.5, 4.5],
@@ -62,14 +62,13 @@ class Test(unittest.TestCase):
                              [0.5, 1.5, 2.5, 3.5, 4.5]])
 
     def test_interp1d(self):
-        N = 3000
-        x = arange(N)
-        y = ones((100, N)) * arange(N)
-        new_x = arange(N)
+        y = ones((100, self.N)) * arange(self.N)
+        new_x = arange(self.N)
         t1 = time.clock()
-        interp = scipy.interpolate.interp1d(x, y)
+        interp = scipy.interpolate.interp1d(self.x, y)
         new_y = interp(new_x)
         t2 = time.clock()
+
         print('scipy interp1d (sec):', t2 - t1)
         self.assertAllclose(new_y[:5, :5],
                             [[0, 1, 2, 3, 4],


### PR DESCRIPTION
- `time.clock()` method deprecation fixed with `time.process_time()`.
- `setUp()` method created.

Fixes #149.