### PR TITLE
Update GitHub Actions workflow to run tests on Python 3.8 as well as 3.6

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 0 * * 5'
 
 env:
-  INSTALL_EDM_VERSION: 3.2.3
+  INSTALL_EDM_VERSION: 3.3.1
 
 jobs:
 
@@ -16,6 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -31,7 +32,7 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install
+        run: edm run -- python etstool.py install --runtime=${{ matrix.runtime }}
       - name: Remove dependencies obtained with edm
         run: |
             edm plumbing remove-package --force traits
@@ -43,4 +44,4 @@ jobs:
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: edm run -- python etstool.py test
+          run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,7 +8,7 @@ on:
     - cron:  '0 0 * * 5'
 
 env:
-  INSTALL_EDM_VERSION: 3.2.3
+  INSTALL_EDM_VERSION: 3.3.1
 
 jobs:
 
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -32,8 +33,8 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install
+        run: edm run -- python etstool.py install --runtime=${{ matrix.runtime }}
       - name: Run tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: edm run -- python etstool.py test
+          run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}

--- a/etstool.py
+++ b/etstool.py
@@ -83,7 +83,7 @@ from contextlib import contextmanager
 
 import click
 
-supported_runtimes = ['3.6']
+supported_runtimes = ['3.6', '3.8']
 
 dependencies = {
     "numpy",


### PR DESCRIPTION
This PR adds Python 3.8 to the test run.

We should expect the Python 3.8 test runs to fail at the moment, thanks to #149.