### PR TITLE
Fix errors and warnings from scimath.interpolate.interpolate main script

### DIFF
--- a/scimath/interpolate/interpolate.py
+++ b/scimath/interpolate/interpolate.py
@@ -134,7 +134,7 @@ def window_average(x, y, new_x, width=10.0):
 
 
 def main():
-    from scipy import arange, ones
+    from numpy import arange, ones
     import time
     N = 3000.
     x = arange(N)
@@ -159,7 +159,7 @@ def main():
 
     N = 3000.
     x = arange(N)
-    y = ones((100, N)) * arange(N)
+    y = ones((100, int(N))) * arange(N)
     new_x = arange(N) + 0.5
     t1 = time.perf_counter()
     new_y = linear(x, y, new_x)
@@ -170,7 +170,7 @@ def main():
     import scipy
     N = 3000.
     x = arange(N)
-    y = ones((100, N)) * arange(N)
+    y = ones((100, int(N))) * arange(N)
     new_x = arange(N)
     t1 = time.perf_counter()
     interp = scipy.interpolate.interp1d(x, y)

--- a/scimath/units/quantity.py
+++ b/scimath/units/quantity.py
@@ -65,7 +65,7 @@ class Quantity(HasPrivateTraits):
         Quantity(2.2, 1.0*m*s**-1)
 
         >>> # an array example
-        >>> from scipy import arange
+        >>> from numpy import arange
         >>> data = arange(3.)
         >>> Quantity(data, meter, 'depth')
         Quantity(depth, [ 0.  1.  2.], 1.0*m)


### PR DESCRIPTION
The `scimath.interpolate.interpolate` main script raise an error about using a float object in a call to `numpy.ones` (actually `scipy.ones`), and warns about uses of deprecation SciPy functions. This PR fixes both the error and the warnings.

Output on main:
```python
(scimath) mdickinson@mirzakhani temp % python -m scimath.interpolate.interpolate
/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py:127: RuntimeWarning: 'scimath.interpolate.interpolate' found in sys.modules after import of package 'scimath.interpolate', but prior to execution of 'scimath.interpolate.interpolate'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:140: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  x = arange(N)
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:141: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  y = arange(N)
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:142: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  new_x = arange(N) + 0.5
1d interp (sec): 0.00013907299999998957
[0.5 1.5 2.5 3.5 4.5]
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:150: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  x = arange(N)
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:151: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  y = arange(N)
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:153: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  new_x = arange(N / 2) * 2
1d block_average_above (sec): 7.863499999999357e-05
[0.  0.5 2.5 4.5 6.5]
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:161: DeprecationWarning: scipy.arange is deprecated and will be removed in SciPy 2.0.0, use numpy.arange instead
  x = arange(N)
/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py:162: DeprecationWarning: scipy.ones is deprecated and will be removed in SciPy 2.0.0, use numpy.ones instead
  y = ones((100, N)) * arange(N)
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py", line 183, in <module>
    main()
  File "/Users/mdickinson/Enthought/ETS/scimath/scimath/interpolate/interpolate.py", line 162, in main
    y = ones((100, N)) * arange(N)
  File "/Users/mdickinson/.venvs/scimath/lib/python3.8/site-packages/scipy/_lib/deprecation.py", line 20, in call
    return fun(*args, **kwargs)
  File "/Users/mdickinson/.venvs/scimath/lib/python3.8/site-packages/numpy/core/numeric.py", line 204, in ones
    a = empty(shape, dtype, order)
TypeError: 'float' object cannot be interpreted as an integer
```

Output on this branch:
```python
(scimath) mdickinson@mirzakhani temp % python -m scimath.interpolate.interpolate
/opt/local/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py:127: RuntimeWarning: 'scimath.interpolate.interpolate' found in sys.modules after import of package 'scimath.interpolate', but prior to execution of 'scimath.interpolate.interpolate'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
1d interp (sec): 0.0002617229999999915
[0.5 1.5 2.5 3.5 4.5]
1d block_average_above (sec): 0.00013140799999999953
[0.  0.5 2.5 4.5 6.5]
fast interpolate (sec): 0.01227455700000002
[[0.5 1.5 2.5 3.5 4.5]
 [0.5 1.5 2.5 3.5 4.5]
 [0.5 1.5 2.5 3.5 4.5]
 [0.5 1.5 2.5 3.5 4.5]
 [0.5 1.5 2.5 3.5 4.5]]
scipy interp1d (sec): 0.009893470999999987
[[0. 1. 2. 3. 4.]
 [0. 1. 2. 3. 4.]
 [0. 1. 2. 3. 4.]
 [0. 1. 2. 3. 4.]
 [0. 1. 2. 3. 4.]]
```