### PR TITLE
Add PyPI Publication workflow

### DIFF
--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
@@ -25,9 +25,9 @@ jobs:
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install Python packages needed for wheel build and upload
       run: |
@@ -55,12 +55,12 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install Python packages needed for sdist build and upload
       run: |

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -31,8 +31,8 @@ jobs:
 
     - name: Install Python packages needed for wheel build and upload
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install twine wheel
+        python -m pip install --upgrade pip
+        python -m pip install twine
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.9.0
@@ -64,12 +64,12 @@ jobs:
 
     - name: Install Python packages needed for sdist build and upload
       run: |
-        python -m pip install --upgrade pip setuptools
-        python -m pip install twine
+        python -m pip install --upgrade pip
+        python -m pip install twine build
 
     - name: Build sdist
       run: |
-        python setup.py sdist
+        python -m build --sdist
 
     - name: Publish sdist to PyPI
       env:

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish release to PyPI
+name: Release to PyPI
 
 on:
   workflow_dispatch:
@@ -6,26 +6,75 @@ on:
     types: [published]
 
 jobs:
-  build-and-upload:
-    runs-on: ubuntu-latest
+  build-wheels:
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
+
     - name: Check out the release commit
       uses: actions/checkout@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: arm64
+      if: runner.os == 'Linux'
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-    - name: Install Python packages needed for build and upload
+
+    - name: Install Python packages needed for wheel build and upload
       run: |
-        python -m pip install build twine
-    - name: Build sdist and wheel
-      run: |
-        python -m build --sdist
-    - name: Publish to PyPI
+        python -m pip install --upgrade pip setuptools
+        python -m pip install twine wheel
+
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.9.0
+      env:
+        CIBW_SKIP: 'pp*'
+        CIBW_ARCHS_LINUX: "auto aarch64"
+        CIBW_ARCHS_MACOS: "auto universal2"
+
+    - name: Check and upload wheels
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m twine check --strict dist/*
-        python -m twine upload dist/*
+        python -m twine check --strict wheelhouse/*.whl
+        python -m twine upload wheelhouse/*.whl
+
+  build-sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install Python packages needed for sdist build and upload
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install twine
+
+    - name: Build sdist
+      run: |
+        python setup.py sdist
+
+    - name: Publish sdist to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*.tar.gz
+        python -m twine upload dist/*.tar.gz

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -76,5 +76,5 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m twine check --strict dist/*.tar.gz
-        python -m twine upload dist/*.tar.gz
+        python -m twine check --strict dist/*
+        python -m twine upload dist/*

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish release to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out the release commit
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install Python packages needed for build and upload
+      run: |
+        python -m pip install build twine
+    - name: Build sdist and wheel
+      run: |
+        python -m build --sdist
+    - name: Publish to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine check --strict dist/*
+        python -m twine upload dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include image_LICENSE.txt
 include LICENSE.txt
 include README.rst
 include pyproject.toml
+include scimath/interpolate/interpolate.h
 recursive-include scimath/units/data *.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["oldest-supported-numpy", "setuptools", "wheel"]
+build-backend = 'setuptools.build_meta'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["numpy", "setuptools", "wheel"]
+requires = ["oldest-supported-numpy", "setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         depends=['interpolate.h']
     )
 
-    extensions = [interpolate] 
+    extensions = [interpolate]
 
     # The actual setup call.
     setup(
@@ -164,6 +164,7 @@ if __name__ == "__main__":
             """.splitlines() if len(c.split()) > 0],
         description = 'scientific and mathematical calculations',
         long_description = open('README.rst').read(),
+        long_description_content_type = "text/x-rst",
         ext_modules=extensions,
         packages=find_packages(exclude=['docs', 'examples']),
         install_requires = DEPENDENCIES,


### PR DESCRIPTION
This is the Traits publication workflow unaltered.  To make it work cleanly,
we needed to:

- add header files to the MANIFEST.in
- set a value for long_description_content_type
- use `oldest-supported-numpy` in the build environment