### PR TITLE
DOC: instruction for test env setup

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,3 +18,10 @@ Prerequisites
 * `Traits <https://pypi.python.org/pypi/traits>`_
 * `NumPy <https://pypi.python.org/pypi/numpy>`_
 * `SciPy <https://pypi.python.org/pypi/scipy>`_
+
+Development Environment Setup
+-------------
+1. Setup the EDM (with click, setuptools and coverage): edm install -e bootstrap click, setuptools, coverage
+2. Activate the EDM environment: edm shell -e bootstrap
+3. Install packages for development: python etstool.py install
+4. Run the tests: python etstool.py test


### PR DESCRIPTION
The previous documentation doesn't include a guide for development setup, which can be challenging to the new developers. This PR adds a setup guide for development environment. Since all the scimath developers are using edm, the setup guide uses edm as well.