### PR TITLE
MAINT: fix unit conversion

### DIFF
--- a/scimath/units/quantity.py
+++ b/scimath/units/quantity.py
@@ -303,8 +303,7 @@ class Quantity(HasPrivateTraits):
             return
 
         # Replace the predecessor's data with converted data.
-        new_quantity = self.change_unit_system(predecessor.units)
-        predecessor.data = new_quantity.data
+        predecessor.data = units_convert(self.data, self.units, predecessor.units)
 
         # Recursively continue propagating.
         predecessor.propagate_data_changes()

--- a/scimath/units/tests/test_units.py
+++ b/scimath/units/tests/test_units.py
@@ -197,6 +197,15 @@ class test_units(unittest.TestCase):
         self.assertAlmostEqual(30., q1.data, 1,
                                "Propagation test expected data 30, got %s" % str(q1.data))
 
+    def test_propagation2(self):
+        """ Tests data propagation for a single converted quantity. """
+
+        q1 = Quantity(10.0, units='ft', family_name='depth')
+        q2 = q1.change_unit_system('METRIC')
+        q2.data = 2 * q2.data
+        q2.propagate_data_changes()
+        self.assertAlmostEqual(q1.data, 20.0)
+
     def test_get_original(self):
 
         q1 = Quantity(10, units='m', family_name='depth')

--- a/scimath/units/tests/test_units.py
+++ b/scimath/units/tests/test_units.py
@@ -197,7 +197,7 @@ class test_units(unittest.TestCase):
         self.assertAlmostEqual(30., q1.data, 1,
                                "Propagation test expected data 30, got %s" % str(q1.data))
 
-    def test_propagation2(self):
+    def test_propagation_to_imperial(self):
         """ Tests data propagation for a single converted quantity. """
 
         q1 = Quantity(10.0, units='ft', family_name='depth')


### PR DESCRIPTION
The original unit conversion done in propagate_data_changes (scimath.units.quantity) can cause conversion error. This PR adds a fix and test for that. closes  issue #171 