### PR TITLE
Fix SciMath package name

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Scimath Documentation
+SciMath Documentation
 ===================================
 
 The SciMath project includes packages to support scientific and mathematical
@@ -26,4 +26,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/source/units/about.rst
+++ b/docs/source/units/about.rst
@@ -1,5 +1,5 @@
 ===============================================================================
-Scimath Units User Manual Copyright Notice
+SciMath Units User Manual Copyright Notice
 ===============================================================================
 
 :Authors: Tim Diller

--- a/docs/source/units/unit_numpy.rst
+++ b/docs/source/units/unit_numpy.rst
@@ -4,8 +4,8 @@
 Units with Numpy
 ===============================================================================
 
-For high-performance computation, Scimath.units includes two objects for adding
-units to `Numpy`_ `ndarray`_ objects: the
+For high-performance computation, ``scimath.units`` includes two objects for
+adding units to `Numpy`_ `ndarray`_ objects: the
 :py:class:`~scimath.units.unit_scalar.UnitScalar` and the
 :py:class:`~scimath.units.unit_scalar.UnitArray`. UnitScalars and UnitArrays
 can be used directly in computations but are best handled with :ref:`unitted

--- a/docs/source/units/user_ref.rst
+++ b/docs/source/units/user_ref.rst
@@ -1,7 +1,7 @@
 .. _user-ref:
 
 ===============================================================================
-Scimath Units User Reference
+SciMath Units User Reference
 ===============================================================================
 
 .. _internal-representation:
@@ -62,4 +62,3 @@ UnitScalar
 UnitArray
 -------------------------------------------------------------------------------
 .. autofunction:: scimath.units.unit_scalar.UnitArray
-


### PR DESCRIPTION
Our docs are slightly inconsistent about the package name: sometimes its spelled as `SciMath`, sometimes as `Scimath`. As far as I can tell, the intended spelling is `SciMath`.

This PR changes occurrences of `Scimath` to either `SciMath` or `scimath`, depending on context.