### PR TITLE
Don't test on macOS/EDM

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,7 +16,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,7 +8,7 @@ on:
     - cron:  '0 0 * * 5'
 
 env:
-  INSTALL_EDM_VERSION: 3.3.1
+  INSTALL_EDM_VERSION: 3.5.0
 
 jobs:
 
@@ -20,14 +20,14 @@ jobs:
         runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache EDM packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v2
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment
@@ -35,6 +35,4 @@ jobs:
       - name: Install test environment
         run: edm run -- python etstool.py install --runtime=${{ matrix.runtime }}
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}
+        run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}


### PR DESCRIPTION
macOS NumPy eggs for EDM are currently incompatible with GitHub-hosted macOS runners: the EDM eggs use AVX2 instructions, which the runners don't support. As a result, our CI jobs are currently failing (see https://github.com/enthought/scimath/actions/runs/4634294059 for an example run):

```
Traceback (most recent call last):
  File "setup.py", line 16, in <module>
    from numpy import get_include
  File "/Users/runner/.edm/envs/scimath-test-3.8/lib/python3.8/site-packages/numpy/__init__.py", line 140, in <module>
    from . import core
  File "/Users/runner/.edm/envs/scimath-test-3.8/lib/python3.8/site-packages/numpy/core/__init__.py", line 23, in <module>
    from . import multiarray
  File "/Users/runner/.edm/envs/scimath-test-3.8/lib/python3.8/site-packages/numpy/core/multiarray.py", line 10, in <module>
    from . import overrides
  File "/Users/runner/.edm/envs/scimath-test-3.8/lib/python3.8/site-packages/numpy/core/overrides.py", line 6, in <module>
    from numpy.core._multiarray_umath import (
RuntimeError: NumPy was built with baseline optimizations: 
(SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C AVX2) but your machine doesn't support:
(AVX2).
```

This PR simply turns off the test runs on macOS/EDM. Note that we're still testing on macOS in the `test-with-pypi.yml` workflow.

Addendum: also updates versions of the various actions used in the workflow so that they'll keep on working later this year.