### PR TITLE
Replace broken imports from version file in setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,11 @@
 
 import os
 import re
-from setuptools import Extension, find_packages, setup
+import runpy
 from subprocess import check_output
 
 from numpy import get_include
+from setuptools import Extension, find_packages, setup
 
 
 MAJOR = 5
@@ -82,13 +83,9 @@ def write_version_py(filename=DEFAULT_VERSION_FILE,
         git_rev, dev_num = git_version()
     elif os.path.exists(DEFAULT_VERSION_FILE):
         # must be a source distribution, use existing version file
-        try:
-            from scimath._version import git_revision as git_rev
-            from scimath._version import full_version as full_v
-        except ImportError:
-            raise ImportError("Unable to import git_revision. Try removing "
-                              "scimath/_version.py and the build directory "
-                              "before building.")
+        context = runpy.run_path(DEFAULT_VERSION_FILE)
+        git_rev = context["git_revision"]
+        full_v = context["full_version"]
         match = re.match(r'.*?\.dev(?P<dev_num>\d+)$', full_v)
         if match is None:
             dev_num = '0'


### PR DESCRIPTION
Closes #178

To verify the fix (on a Unix-a-like platform), execute the following instructions from the repository root, replacing the build number in the sdist as appropriate:

```
python -m venv --clear scimath_env
source scimath_env/bin/activate
pip install build
python -m build --sdist
cd dist
pip install scimath-5.1.0.dev423.tar.gz
```

The above works for me on this branch, but on `main` the final `pip install` step fails with an error resembling that reported in #178:

```
(scimath_env) mdickinson@mirzakhani dist % pip install scimath-5.1.0.dev423.tar.gz
WARNING: Requirement 'scimath-5.1.0.dev423.tar.gz' looks like a filename, but the file does not exist
Processing ./scimath-5.1.0.dev423.tar.gz
ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: '/Users/mdickinson/Enthought/ETS/scimath/dist/scimath-5.1.0.dev423.tar.gz'

(scimath_env) mdickinson@mirzakhani dist % ls
scimath-5.1.0.dev422.tar.gz
(scimath_env) mdickinson@mirzakhani dist % pip install scimath-5.1.0.dev422.tar.gz 
Processing ./scimath-5.1.0.dev422.tar.gz
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Traceback (most recent call last):
        File "<string>", line 86, in write_version_py
      ModuleNotFoundError: No module named 'scimath'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/Users/mdickinson/Enthought/ETS/scimath/scimath_env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/mdickinson/Enthought/ETS/scimath/scimath_env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/mdickinson/Enthought/ETS/scimath/scimath_env/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/07/jbbjv8b53bs5y9xyjdyn1zgw0000gn/T/pip-build-env-sx5r8mb8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/07/jbbjv8b53bs5y9xyjdyn1zgw0000gn/T/pip-build-env-sx5r8mb8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/07/jbbjv8b53bs5y9xyjdyn1zgw0000gn/T/pip-build-env-sx5r8mb8/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 122, in <module>
        File "<string>", line 89, in write_version_py
      ImportError: Unable to import git_revision. Try removing scimath/_version.py and the build directory before building.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```