### PR TITLE
Update action versions and EDM version

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 0 * * 5'
 
 env:
-  INSTALL_EDM_VERSION: 3.3.1
+  INSTALL_EDM_VERSION: 3.7.0
 
 jobs:
 
@@ -19,14 +19,14 @@ jobs:
         runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Cache EDM packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v1
+        uses: enthought/setup-edm-action@v3
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment
@@ -42,6 +42,4 @@ jobs:
             edm run -- python -m pip install --force-reinstall "git+http://github.com/enthought/traits.git#egg=traits"
             edm run -- python -m pip install --force-reinstall scipy
       - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}
+        run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}

--- a/.github/workflows/release-to-pypi.yml
+++ b/.github/workflows/release-to-pypi.yml
@@ -16,16 +16,16 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
       if: runner.os == 'Linux'
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -33,7 +33,7 @@ jobs:
       run: python -m pip install twine
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.9.0
+      uses: pypa/cibuildwheel@v2.16.5
 
     - name: Check and upload wheels
       env:
@@ -49,10 +49,10 @@ jobs:
     steps:
 
     - name: Check out the release commit
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,7 +8,7 @@ on:
     - cron:  '0 0 * * 5'
 
 env:
-  INSTALL_EDM_VERSION: 3.5.0
+  INSTALL_EDM_VERSION: 3.7.0
 
 jobs:
 
@@ -20,14 +20,14 @@ jobs:
         runtime: ['3.6', '3.8']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Cache EDM packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache
           key: ${{ runner.os }}-${{ hashFiles('etstool.py') }}
       - name: Set up EDM
-        uses: enthought/setup-edm-action@v2
+        uses: enthought/setup-edm-action@v3
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment

--- a/.github/workflows/test-with-pypi.yml
+++ b/.github/workflows/test-with-pypi.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone the SciMath source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install package under test


### PR DESCRIPTION
We're getting warnings about outdated GitHub Actions. This PR brings all actions up to the most recent versions.

~I'm not yet sure whether it's safe to remove the use of GabrielBB/xvfb-action@v1 altogether or whether we need to introduce an explicit use of `xvfb-run -a` on Ubuntu workers. Testing that workflow is currently blocked by the `python setup.py install` failure fixed in #182.~

Update: #182 is merged, and it looks as though everything's working despite the removal of the xvfb-action.

Test run: https://github.com/enthought/scimath/actions/runs/8112365378

