### PR TITLE
Fix bleeding edge workflow

### DIFF
--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        runtime: ['3.6', '3.8']
+        runtime: ['3.8']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -32,11 +32,14 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install --runtime=${{ matrix.runtime }}
+        run: |
+          edm run -- python etstool.py install \
+            --runtime ${{ matrix.runtime }} \
+            --environment scimath-test
       - name: Remove dependencies obtained with edm
         run: |
-            edm plumbing remove-package --force traits
-            edm plumbing remove-package --force scipy
+            edm plumbing remove-package --environment scimath-test traits
+            edm plumbing remove-package --environment scimath-test scipy
       - name: Re-install dependencies using pip
         run: |
             edm run -- python -m pip install --force-reinstall "git+http://github.com/enthought/traits.git#egg=traits"

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -32,10 +32,7 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: |
-          edm run -- python etstool.py install \
-            --runtime ${{ matrix.runtime }} \
-            --environment scimath-test
+        run: edm run -- python etstool.py install --runtime ${{ matrix.runtime }} --environment scimath-test
       - name: Remove dependencies obtained with edm
         run: |
             edm plumbing remove-package --environment scimath-test traits

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -42,4 +42,4 @@ jobs:
             edm run -- python -m pip install --force-reinstall "git+http://github.com/enthought/traits.git#egg=traits"
             edm run -- python -m pip install --force-reinstall scipy
       - name: Run tests
-        run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }}
+        run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }} --environment scimath-test

--- a/.github/workflows/bleeding-edge.yml
+++ b/.github/workflows/bleeding-edge.yml
@@ -39,7 +39,7 @@ jobs:
             edm plumbing remove-package --environment scimath-test scipy
       - name: Re-install dependencies using pip
         run: |
-            edm run -- python -m pip install --force-reinstall "git+http://github.com/enthought/traits.git#egg=traits"
-            edm run -- python -m pip install --force-reinstall scipy
+            edm run --environment scimath-test -- python -m pip install --force-reinstall "git+http://github.com/enthought/traits.git#egg=traits"
+            edm run --environment scimath-test -- python -m pip install --force-reinstall scipy
       - name: Run tests
         run: edm run -- python etstool.py test --runtime=${{ matrix.runtime }} --environment scimath-test


### PR DESCRIPTION
This PR fixes two issues with the bleeding edge workflow - one long-standing, and one recently introduced

- Problem 1: we weren't actually modifying the test environment: the package replacements were happening on the "bootstrap" edm environment ("edm"). So the bleeding edge workflow has apparently not been working as intended for some time.
- Problem 2: the bleeding edge version of Traits now requires Python >= 3.8, so we can't run the tests on Python 3.6.

Successful test run (after a few false starts): https://github.com/enthought/scimath/actions/runs/8112365378