### PR TITLE
Replace oldest-supported-numpy with numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["oldest-supported-numpy", "setuptools", "wheel"]
+requires = ["numpy", "setuptools", "wheel"]
 build-backend = 'setuptools.build_meta'
 
 [tool.cibuildwheel]


### PR DESCRIPTION
This is an attempt to get CI working again. We should be listing NumPy rather than oldest-supported-numpy as a build dependency.

xref: https://github.com/scipy/oldest-supported-numpy?tab=readme-ov-file#deprecation-notice-for-numpy-20
